### PR TITLE
Explorer UI reorganization, subtree-as-root focus, and metadata warnings

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -354,18 +354,20 @@ Root (src/Root.js)
             +-- CollapsibleSection: "Datasets"
             |   +-- DatasetLoadingTable  # Dataset selection for loading
             |
-            +-- CollapsibleSection: "Clonal Families"
+            +-- CollapsibleSection: "Filters" [conditional]
             |   +-- FilterPanel      # High-level filters (locus, subject, etc.)
+            |
+            +-- CollapsibleSection: "Clonal Family Scatterplot"
             |   +-- SelectedFamiliesSummary  # Count display
             |   +-- ClonalFamiliesViz  # Vega scatterplot wrapper
             |       +-- facetScatterPlot  # Vega spec
             |
-            +-- CollapsibleSection: "Selected Clonal Families"
+            +-- CollapsibleSection: "Clonal Family Selection Table"
             |   +-- ClonalFamiliesTable  # Paginated table
             |       +-- ResizableTable   # Column resize support
             |       +-- RowInfoModal     # Metadata viewer
             |
-            +-- CollapsibleSection: "Clonal Family Details" [conditional]
+            +-- CollapsibleSection: "Clonal Family Tree & Alignment" [conditional]
             |   +-- TreeViz          # Tree visualization wrapper
             |       +-- clonalFamilyDetails  # Vega tree + alignment spec
             |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,24 @@
+## version 2.7.0 - 2026/04/20
+Changed:
+* Filters promoted to a top-level section with its own help panel and live "passed filter" banner (turns red when filters exclude everything)
+* Section headers renamed: Clonal Families → Clonal Family Scatterplot, Selected Clonal Families → Clonal Family Selection Table, Clonal Family Details → Clonal Family Tree & Alignment
+* Active Datasets panel listing loaded datasets above Available Data Fields
+* Warning banner when a loaded dataset has no field_metadata (falls back to defaults)
+* Union/Intersection toggle ("Show Only Shared Data Fields" / "Show All Data Fields") for the field listing when 2+ datasets are loaded
+* Field display-mode legend updated to colored dots (🟢 dropdown, 🟡 tooltip, 🔴 skip)
+* Update Visualization button reads "Visualization Up-to-Date" when no changes are pending; selections persist after update
+* New Clear Selections button next to Update Visualization
+* Clonal Family Tree & Alignment header split: family name, Chain, and Ancestral Reconstruction Method are now labeled fields below the title; Chain is always visible (pinned when unpaired); blank reconstruction methods render as `<unspecified>`
+* New "Treat subtree as root" focus mode: regenerates the tree alignment using the subtree root's sequence as naive; cascades into Ancestral Sequences via a new computeLineageDataRelativeTo selector
+* Bugfix: synthetic-root forest assembly demotes original roots to `type: "node"`, preventing duplicate stacked naive alignment rows
+
 ## version 2.6.0 - 2026/04/01
 Changed:
 * All visualization controls (dropdowns, tooltips, filters) driven dynamically by field_metadata from olmsted-cli
 * Centralized metadata resolution with DEFAULT and BUILTIN field definitions per level (clone, node, branch, mutation)
 * Mutation coloring system: AA color scale, continuous heatmap with dynamic domain, color scheme dropdown
 * Mutation settings cascade from tree view to lineage view via VegaViewContext
-* Available Fields summary with display mode indicators after dataset loading
+* Available Data Fields summary with display mode indicators after dataset loading
 * Collapsible JSON structures in Info modals
 * Shared Vega tooltip expression builder for consistent tooltip rendering
 * 577 tests across 28 suites

--- a/README.md
+++ b/README.md
@@ -158,9 +158,9 @@ Olmsted uses a client-side database to manage your datasets within the browser. 
 
 Once you're in the visualization interface, you can change your dataset selection on demand. Simply select the desired datasets in the dataset table on the visualization page, then click the "Update Visualization" button to refresh the view with your new selection. "Manage Datasets" will return you to the splash page.
 
-### Clonal Families Section (AKA "scatterplot")
+### Clonal Family Scatterplot
 
-The *Clonal Families* section represents each clonal family as a point in a scatterplot:
+The *Clonal Family Scatterplot* section represents each clonal family as a point in a scatterplot:
 
 ![scatterplot](docs/clonal-families-section.png)
 
@@ -173,9 +173,9 @@ For comparison of subsets, you may *facet* the plot into separated panels accord
 
 ![facet](docs/facet.png)
 
-Interact with the plot by clicking and dragging across a subset of points or clicking individual points to filter the resulting clonal families in the *Selected clonal families* table below.
+Interact with the plot by clicking and dragging across a subset of points or clicking individual points to filter the resulting clonal families in the *Clonal Family Selection Table* below.
 
-### Selected Clonal Families Section (AKA "table")
+### Clonal Family Selection Table
 Below the scatterplot, the full collection or selected subset of clonal families appears in a table including a visualization of the recombination event resulting in the naive antibody sequence and a subset of clonal family metadata:
 
 ![table](docs/selected-clonal-families-section.png)
@@ -183,10 +183,10 @@ Below the scatterplot, the full collection or selected subset of clonal families
 Each row in the table represents one clonal family.
 The table automatically selects the top clonal family according to the sorting column.
 Click on the checkbox in the "Select" column in the table to select a clonal family for further visualization.
-Upon selecting a clonal family from the table, the phylogenetic tree(s) corresponding to that clonal family (as specified in the input JSON) is visualized below the table in the Clonal family details section.
+Upon selecting a clonal family from the table, the phylogenetic tree(s) corresponding to that clonal family (as specified in the input JSON) is visualized below the table in the Clonal Family Tree & Alignment section.
 
-### Clonal Family Details Section (AKA "tree" and "alignment")
-For a selected clonal family, its phylogenetic tree is visualized below the table in the *Clonal family details* section:
+### Clonal Family Tree & Alignment
+For a selected clonal family, its phylogenetic tree is visualized below the table in the *Clonal Family Tree & Alignment* section:
 
 ![tree align view](docs/clonal-family-details-section.png)
 
@@ -219,7 +219,7 @@ The *Ancestral Sequences* section displays an alignment of the selected sequence
 
 ![lineage view](docs/ancestral-sequences-section.png)
 
-Mutations from the naive sequence are shown as in the *Clonal Family Details* section.
+Mutations from the naive sequence are shown as in the *Clonal Family Tree & Alignment* section.
 
 ## Local Deployment
 

--- a/src/actions/explorer.js
+++ b/src/actions/explorer.js
@@ -178,6 +178,15 @@ export const updateLineageChain = (chain) => {
   return { type: types.UPDATE_LINEAGE_CHAIN, chain };
 };
 
+// Subtree focus actions (shared with lineage view)
+export const updateSubtreeRoot = (subtreeRoot) => {
+  return { type: types.UPDATE_SUBTREE_ROOT, subtreeRoot };
+};
+
+export const updateTreatSubtreeAsRoot = (treatAsRoot) => {
+  return { type: types.UPDATE_TREAT_SUBTREE_AS_ROOT, treatAsRoot };
+};
+
 // Current section (for nav bar display)
 export const updateCurrentSection = (section) => {
   return { type: types.UPDATE_CURRENT_SECTION, section };

--- a/src/actions/types.js
+++ b/src/actions/types.js
@@ -92,6 +92,10 @@ export const UPDATE_LINEAGE_SHOW_ENTIRE = "UPDATE_LINEAGE_SHOW_ENTIRE";
 export const UPDATE_LINEAGE_SHOW_BORDERS = "UPDATE_LINEAGE_SHOW_BORDERS";
 export const UPDATE_LINEAGE_CHAIN = "UPDATE_LINEAGE_CHAIN";
 
+// Subtree focus state (shared between Phylogeny and Ancestral Sequences views)
+export const UPDATE_SUBTREE_ROOT = "UPDATE_SUBTREE_ROOT";
+export const UPDATE_TREAT_SUBTREE_AS_ROOT = "UPDATE_TREAT_SUBTREE_AS_ROOT";
+
 // Visualization config actions
 export const CONFIGS_LOADED = "CONFIGS_LOADED";
 export const CONFIG_SAVED = "CONFIG_SAVED";

--- a/src/components/explorer/DatasetLoadingTable.js
+++ b/src/components/explorer/DatasetLoadingTable.js
@@ -9,7 +9,7 @@ import { getClientClonalFamilies } from "../../actions/clientDataLoader";
 import { getClonalFamilies } from "../../actions/loadData";
 import * as explorerActions from "../../actions/explorer";
 import { resolveFieldMetadata } from "../../utils/fieldMetadata";
-import { DEFAULT_DISPLAY } from "../../constants/fieldDefaults";
+import { DEFAULT_DISPLAY, DISPLAY_MODE_ICONS } from "../../constants/fieldDefaults";
 import * as types from "../../actions/types";
 import DownloadCSV from "../util/downloadCsv";
 import {
@@ -22,6 +22,57 @@ import {
   MissingFieldsCell
 } from "../tables/DatasetTableCells";
 import { DatasetInfoCell } from "../tables/RowInfoModal";
+
+// --- Shared constants and helpers ---
+
+const FIELD_VIEW_MODES = { UNION: "union", INTERSECTION: "intersection" };
+
+const SESSION_KEYS = {
+  sortStarredFirst: "olmsted_datasets_sort_starred_first",
+  showOnlyStarred: "olmsted_datasets_show_only_starred",
+  hideServerData: "olmsted_datasets_hide_server",
+  fieldViewMode: "olmsted_datasets_field_view_mode"
+};
+
+// JSON-encoded session read with a fallback when the key is missing or unparseable.
+const readSessionJson = (key, fallback) => {
+  try {
+    const raw = sessionStorage.getItem(key);
+    return raw === null ? fallback : JSON.parse(raw);
+  } catch (_e) {
+    return fallback;
+  }
+};
+
+// Enum-valued session read that restricts to a list of allowed values.
+const readSessionEnum = (key, allowed, fallback) => {
+  try {
+    const raw = sessionStorage.getItem(key);
+    return allowed.includes(raw) ? raw : fallback;
+  } catch (_e) {
+    return fallback;
+  }
+};
+
+// Silent session write; ignores quota/privacy errors.
+const writeSession = (key, value) => {
+  try {
+    sessionStorage.setItem(key, typeof value === "string" ? value : JSON.stringify(value));
+  } catch (_e) {
+    /* ignore */
+  }
+};
+
+// Hoisted style objects for FieldViewModeToggle so they aren't recreated per render.
+const TOGGLE_BASE_BTN = {
+  border: "1px solid #ced4da",
+  padding: "2px 8px",
+  fontSize: 11,
+  cursor: "pointer",
+  lineHeight: 1.4
+};
+const TOGGLE_ACTIVE_BTN = { backgroundColor: "#007bff", color: "#fff", borderColor: "#007bff" };
+const TOGGLE_INACTIVE_BTN = { backgroundColor: "#fff", color: "#495057" };
 
 // Component for non-selectable load status display
 function LoadStatusDisplay({ datum }) {
@@ -42,15 +93,6 @@ function LoadStatusDisplay({ datum }) {
 
 // Segmented control for toggling Available Fields between union and intersection of loaded datasets.
 function FieldViewModeToggle({ mode, onChange }) {
-  const baseBtn = {
-    border: "1px solid #ced4da",
-    padding: "2px 8px",
-    fontSize: 11,
-    cursor: "pointer",
-    lineHeight: 1.4
-  };
-  const activeBtn = { backgroundColor: "#007bff", color: "#fff", borderColor: "#007bff" };
-  const inactiveBtn = { backgroundColor: "#fff", color: "#495057" };
   return (
     <span
       style={{ display: "inline-flex" }}
@@ -58,10 +100,10 @@ function FieldViewModeToggle({ mode, onChange }) {
     >
       <button
         type="button"
-        onClick={() => onChange("intersection")}
+        onClick={() => onChange(FIELD_VIEW_MODES.INTERSECTION)}
         style={{
-          ...baseBtn,
-          ...(mode === "intersection" ? activeBtn : inactiveBtn),
+          ...TOGGLE_BASE_BTN,
+          ...(mode === FIELD_VIEW_MODES.INTERSECTION ? TOGGLE_ACTIVE_BTN : TOGGLE_INACTIVE_BTN),
           borderTopLeftRadius: 3,
           borderBottomLeftRadius: 3
         }}
@@ -70,10 +112,10 @@ function FieldViewModeToggle({ mode, onChange }) {
       </button>
       <button
         type="button"
-        onClick={() => onChange("union")}
+        onClick={() => onChange(FIELD_VIEW_MODES.UNION)}
         style={{
-          ...baseBtn,
-          ...(mode === "union" ? activeBtn : inactiveBtn),
+          ...TOGGLE_BASE_BTN,
+          ...(mode === FIELD_VIEW_MODES.UNION ? TOGGLE_ACTIVE_BTN : TOGGLE_INACTIVE_BTN),
           borderTopRightRadius: 3,
           borderBottomRightRadius: 3,
           marginLeft: -1
@@ -132,30 +174,14 @@ export default class DatasetLoadingTable extends React.Component {
     super(props);
     this.handleBatchUpdate = this.handleBatchUpdate.bind(this);
     // Load preferences from sessionStorage
-    let sortStarredFirst = true;
-    let showOnlyStarred = false;
-    try {
-      const savedSort = sessionStorage.getItem("olmsted_datasets_sort_starred_first");
-      if (savedSort !== null) sortStarredFirst = JSON.parse(savedSort);
-      const savedFilter = sessionStorage.getItem("olmsted_datasets_show_only_starred");
-      if (savedFilter !== null) showOnlyStarred = JSON.parse(savedFilter);
-    } catch (_e) {
-      // ignore
-    }
-    let hideServerData = false;
-    try {
-      const savedHide = sessionStorage.getItem("olmsted_datasets_hide_server");
-      if (savedHide !== null) hideServerData = JSON.parse(savedHide);
-    } catch (_e) {
-      // ignore
-    }
-    let fieldViewMode = "intersection";
-    try {
-      const savedMode = sessionStorage.getItem("olmsted_datasets_field_view_mode");
-      if (savedMode === "union" || savedMode === "intersection") fieldViewMode = savedMode;
-    } catch (_e) {
-      // ignore
-    }
+    const sortStarredFirst = readSessionJson(SESSION_KEYS.sortStarredFirst, true);
+    const showOnlyStarred = readSessionJson(SESSION_KEYS.showOnlyStarred, false);
+    const hideServerData = readSessionJson(SESSION_KEYS.hideServerData, false);
+    const fieldViewMode = readSessionEnum(
+      SESSION_KEYS.fieldViewMode,
+      [FIELD_VIEW_MODES.UNION, FIELD_VIEW_MODES.INTERSECTION],
+      FIELD_VIEW_MODES.INTERSECTION
+    );
     this.state = {
       updateHovered: false,
       manageHovered: false,
@@ -174,11 +200,7 @@ export default class DatasetLoadingTable extends React.Component {
   toggleSortStarredFirst = () => {
     this.setState((prevState) => {
       const newValue = !prevState.sortStarredFirst;
-      try {
-        sessionStorage.setItem("olmsted_datasets_sort_starred_first", JSON.stringify(newValue));
-      } catch (_e) {
-        /* ignore */
-      }
+      writeSession(SESSION_KEYS.sortStarredFirst, newValue);
       return { sortStarredFirst: newValue };
     });
   };
@@ -186,11 +208,7 @@ export default class DatasetLoadingTable extends React.Component {
   toggleShowOnlyStarred = () => {
     this.setState((prevState) => {
       const newValue = !prevState.showOnlyStarred;
-      try {
-        sessionStorage.setItem("olmsted_datasets_show_only_starred", JSON.stringify(newValue));
-      } catch (_e) {
-        /* ignore */
-      }
+      writeSession(SESSION_KEYS.showOnlyStarred, newValue);
       return { showOnlyStarred: newValue };
     });
   };
@@ -198,21 +216,13 @@ export default class DatasetLoadingTable extends React.Component {
   toggleHideServerData = () => {
     this.setState((prevState) => {
       const newValue = !prevState.hideServerData;
-      try {
-        sessionStorage.setItem("olmsted_datasets_hide_server", JSON.stringify(newValue));
-      } catch (_e) {
-        /* ignore */
-      }
+      writeSession(SESSION_KEYS.hideServerData, newValue);
       return { hideServerData: newValue };
     });
   };
 
   setFieldViewMode = (mode) => {
-    try {
-      sessionStorage.setItem("olmsted_datasets_field_view_mode", mode);
-    } catch (_e) {
-      /* ignore */
-    }
+    writeSession(SESSION_KEYS.fieldViewMode, mode);
     this.setState({ fieldViewMode: mode });
   };
 
@@ -365,7 +375,7 @@ export default class DatasetLoadingTable extends React.Component {
 
     // Intersection: only fields shared across all datasets.
     // Union: all fields, with partials marked inline.
-    const isUnion = this.state.fieldViewMode === "union" && totalDatasets > 1;
+    const isUnion = this.state.fieldViewMode === FIELD_VIEW_MODES.UNION && totalDatasets > 1;
     const displayedFields = isUnion ? fieldList : sharedFields;
     const fieldsByLevel = {};
     for (const level of allLevels) {
@@ -402,7 +412,7 @@ export default class DatasetLoadingTable extends React.Component {
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
           <span style={{ fontWeight: "bold", fontSize: 13 }}>Available Data Fields</span>
           <span style={{ color: "#888", fontSize: 11 }}>
-            🟢 dropdown 🟡 tooltip 🔴 skip
+            {DISPLAY_MODE_ICONS.dropdown} dropdown {DISPLAY_MODE_ICONS.tooltip} tooltip {DISPLAY_MODE_ICONS.skip} skip
             {totalDatasets > 1 && isUnion ? " † partial (hover for datasets)" : ""}
           </span>
         </div>
@@ -419,7 +429,7 @@ export default class DatasetLoadingTable extends React.Component {
               <span style={{ color: fields.length > 0 ? "#333" : "#999" }}>
                 {fields.length > 0
                   ? fields.map((f, i) => {
-                      const icon = f.display === "skip" ? "🔴" : f.display === "tooltip" ? "🟡" : "🟢";
+                      const icon = DISPLAY_MODE_ICONS[f.display] || DISPLAY_MODE_ICONS.dropdown;
                       const isPartial = f.datasets.size < totalDatasets;
                       return (
                         <React.Fragment key={`${f.level}.${f.field}`}>
@@ -733,8 +743,7 @@ export default class DatasetLoadingTable extends React.Component {
               padding: "8px 16px",
               fontSize: "14px",
               fontWeight: "bold",
-              backgroundColor:
-                selectedDatasets.length === 0 ? "#6c757d" : this.state.clearSelectionsHovered ? "#5a6268" : "#6c757d",
+              backgroundColor: this.state.clearSelectionsHovered && selectedDatasets.length > 0 ? "#e8700e" : "#fd7e14",
               color: "white",
               border: "none",
               borderRadius: "4px",

--- a/src/components/explorer/DatasetLoadingTable.js
+++ b/src/components/explorer/DatasetLoadingTable.js
@@ -1,7 +1,7 @@
 import React from "react";
 import { connect } from "react-redux";
 import * as _ from "lodash";
-import { FiRefreshCw, FiDatabase, FiStar } from "react-icons/fi";
+import { FiRefreshCw, FiDatabase, FiStar, FiX } from "react-icons/fi";
 import { GreenCheckmark, LoadingStatus } from "../util/loading";
 import { countLoadedClonalFamilies } from "../../selectors/clonalFamilies";
 import { ResizableTable } from "../util/resizableTable";
@@ -37,6 +37,51 @@ function LoadStatusDisplay({ datum }) {
     <div style={{ width: "100%", textAlign: "center" }}>
       <LoadingStatus loadingStatus={datum.loading} />
     </div>
+  );
+}
+
+// Segmented control for toggling Available Fields between union and intersection of loaded datasets.
+function FieldViewModeToggle({ mode, onChange }) {
+  const baseBtn = {
+    border: "1px solid #ced4da",
+    padding: "2px 8px",
+    fontSize: 11,
+    cursor: "pointer",
+    lineHeight: 1.4
+  };
+  const activeBtn = { backgroundColor: "#007bff", color: "#fff", borderColor: "#007bff" };
+  const inactiveBtn = { backgroundColor: "#fff", color: "#495057" };
+  return (
+    <span
+      style={{ display: "inline-flex" }}
+      title="Union shows every field present in any dataset; Intersection shows only fields shared by all datasets."
+    >
+      <button
+        type="button"
+        onClick={() => onChange("intersection")}
+        style={{
+          ...baseBtn,
+          ...(mode === "intersection" ? activeBtn : inactiveBtn),
+          borderTopLeftRadius: 3,
+          borderBottomLeftRadius: 3
+        }}
+      >
+        Show Only Shared Data Fields
+      </button>
+      <button
+        type="button"
+        onClick={() => onChange("union")}
+        style={{
+          ...baseBtn,
+          ...(mode === "union" ? activeBtn : inactiveBtn),
+          borderTopRightRadius: 3,
+          borderBottomRightRadius: 3,
+          marginLeft: -1
+        }}
+      >
+        Show All Data Fields
+      </button>
+    </span>
   );
 }
 
@@ -104,6 +149,13 @@ export default class DatasetLoadingTable extends React.Component {
     } catch (_e) {
       // ignore
     }
+    let fieldViewMode = "intersection";
+    try {
+      const savedMode = sessionStorage.getItem("olmsted_datasets_field_view_mode");
+      if (savedMode === "union" || savedMode === "intersection") fieldViewMode = savedMode;
+    } catch (_e) {
+      // ignore
+    }
     this.state = {
       updateHovered: false,
       manageHovered: false,
@@ -111,9 +163,11 @@ export default class DatasetLoadingTable extends React.Component {
       sortStarredFirst,
       showOnlyStarred,
       hideServerData,
+      fieldViewMode,
       starAllHovered: false,
       unstarAllHovered: false,
-      clearStarsHovered: false
+      clearStarsHovered: false,
+      clearSelectionsHovered: false
     };
   }
 
@@ -151,6 +205,15 @@ export default class DatasetLoadingTable extends React.Component {
       }
       return { hideServerData: newValue };
     });
+  };
+
+  setFieldViewMode = (mode) => {
+    try {
+      sessionStorage.setItem("olmsted_datasets_field_view_mode", mode);
+    } catch (_e) {
+      /* ignore */
+    }
+    this.setState({ fieldViewMode: mode });
   };
 
   componentDidMount() {
@@ -204,8 +267,9 @@ export default class DatasetLoadingTable extends React.Component {
       }
     });
 
-    // Clear selections after processing
-    dispatch(explorerActions.clearDatasetSelections());
+    // Intentionally do NOT clear selections here: after a successful update,
+    // selections should reflect what is loaded so the button settles into the
+    // "Visualization Up-to-Date" state until the user toggles something.
   }
 
   /**
@@ -213,6 +277,50 @@ export default class DatasetLoadingTable extends React.Component {
    * @param {Object[]} allDatasetsToUse - The datasets currently displayed in the table
    * @returns {React.ReactNode|null}
    */
+  /**
+   * Render a small panel listing the currently active (loaded) datasets.
+   * Shown directly above the Available Data Fields panel.
+   * @param {Object[]} allDatasetsToUse - The datasets currently displayed in the table
+   * @returns {React.ReactNode|null}
+   */
+  renderLoadedDatasetsList(allDatasetsToUse) {
+    const loadedDatasets = allDatasetsToUse.filter((d) => d.loading === "DONE");
+    if (loadedDatasets.length === 0) return null;
+    return (
+      <div
+        style={{
+          marginTop: 10,
+          padding: "10px 14px",
+          backgroundColor: "#f8f9fa",
+          border: "1px solid #dee2e6",
+          borderRadius: 4,
+          fontSize: 12
+        }}
+      >
+        <div style={{ fontWeight: "bold", fontSize: 13, marginBottom: 6 }}>
+          Active Datasets ({loadedDatasets.length})
+        </div>
+        <ul style={{ margin: 0, paddingLeft: 18 }}>
+          {loadedDatasets.map((ds) => {
+            const name = ds.name || ds.dataset_id;
+            const count = typeof ds.clone_count === "number" ? ds.clone_count : null;
+            return (
+              <li key={ds.dataset_id}>
+                <span style={{ fontWeight: 500 }}>{name}</span>
+                {count !== null && (
+                  <span style={{ color: "#666" }}>
+                    {" "}
+                    — {count} clonal {count === 1 ? "family" : "families"}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+    );
+  }
+
   renderFieldSummary(allDatasetsToUse) {
     const loadedDatasets = allDatasetsToUse.filter((d) => d.loading === "DONE");
     if (loadedDatasets.length === 0) return null;
@@ -255,10 +363,13 @@ export default class DatasetLoadingTable extends React.Component {
     const sharedFields = fieldList.filter((f) => f.datasets.size === totalDatasets);
     const partialFields = fieldList.filter((f) => f.datasets.size < totalDatasets);
 
-    // Group shared fields by level, show all levels
-    const sharedByLevel = {};
+    // Intersection: only fields shared across all datasets.
+    // Union: all fields, with partials marked inline.
+    const isUnion = this.state.fieldViewMode === "union" && totalDatasets > 1;
+    const displayedFields = isUnion ? fieldList : sharedFields;
+    const fieldsByLevel = {};
     for (const level of allLevels) {
-      sharedByLevel[level] = sharedFields.filter((f) => f.level === level);
+      fieldsByLevel[level] = displayedFields.filter((f) => f.level === level);
     }
 
     return (
@@ -289,30 +400,45 @@ export default class DatasetLoadingTable extends React.Component {
           </div>
         )}
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
-          <span style={{ fontWeight: "bold", fontSize: 13 }}>
-            Available Fields ({totalDatasets} dataset{totalDatasets > 1 ? "s" : ""})
+          <span style={{ fontWeight: "bold", fontSize: 13 }}>Available Data Fields</span>
+          <span style={{ color: "#888", fontSize: 11 }}>
+            🟢 dropdown 🟡 tooltip 🔴 skip
+            {totalDatasets > 1 && isUnion ? " † partial (hover for datasets)" : ""}
           </span>
-          <span style={{ color: "#888", fontSize: 11 }}>🔵 dropdown ⚪ tooltip ⊘ skip</span>
         </div>
+        {totalDatasets > 1 && (
+          <div style={{ marginBottom: 6 }}>
+            <FieldViewModeToggle mode={this.state.fieldViewMode} onChange={this.setFieldViewMode} />
+          </div>
+        )}
         {allLevels.map((level) => {
-          const fields = sharedByLevel[level];
+          const fields = fieldsByLevel[level];
           return (
             <div key={level} style={{ marginBottom: 4 }}>
               <span style={{ fontWeight: 500, color: "#555" }}>{level}:</span>{" "}
               <span style={{ color: fields.length > 0 ? "#333" : "#999" }}>
                 {fields.length > 0
-                  ? fields
-                      .map((f) => {
-                        const icon = f.display === "skip" ? "⊘" : f.display === "tooltip" ? "⚪" : "🔵";
-                        return `${icon}\u00A0${f.label}`;
-                      })
-                      .join(",  ")
+                  ? fields.map((f, i) => {
+                      const icon = f.display === "skip" ? "🔴" : f.display === "tooltip" ? "🟡" : "🟢";
+                      const isPartial = f.datasets.size < totalDatasets;
+                      return (
+                        <React.Fragment key={`${f.level}.${f.field}`}>
+                          {i > 0 ? ",  " : ""}
+                          <span
+                            title={isPartial ? `Only in: ${[...f.datasets].join(", ")}` : undefined}
+                            style={isPartial ? { color: "#856404" } : undefined}
+                          >
+                            {`${icon} ${f.label}${isPartial ? " †" : ""}`}
+                          </span>
+                        </React.Fragment>
+                      );
+                    })
                   : "(none)"}
               </span>
             </div>
           );
         })}
-        {partialFields.length > 0 && totalDatasets > 1 && !this.state.fieldWarningDismissed && (
+        {!isUnion && partialFields.length > 0 && totalDatasets > 1 && !this.state.fieldWarningDismissed && (
           <div
             style={{
               marginTop: 8,
@@ -592,7 +718,38 @@ export default class DatasetLoadingTable extends React.Component {
             }}
           >
             <FiRefreshCw size={16} />
-            Update Visualization {pendingChanges > 0 ? `(${pendingChanges} changes pending)` : ""}
+            {pendingChanges > 0
+              ? `Update Visualization (${pendingChanges} changes pending)`
+              : "Visualization Up-to-Date"}
+          </button>
+
+          <button
+            type="button"
+            onClick={() => dispatch(explorerActions.clearDatasetSelections())}
+            disabled={selectedDatasets.length === 0}
+            onMouseEnter={() => this.setState({ clearSelectionsHovered: true })}
+            onMouseLeave={() => this.setState({ clearSelectionsHovered: false })}
+            style={{
+              padding: "8px 16px",
+              fontSize: "14px",
+              fontWeight: "bold",
+              backgroundColor:
+                selectedDatasets.length === 0 ? "#6c757d" : this.state.clearSelectionsHovered ? "#5a6268" : "#6c757d",
+              color: "white",
+              border: "none",
+              borderRadius: "4px",
+              cursor: selectedDatasets.length === 0 ? "not-allowed" : "pointer",
+              marginRight: "10px",
+              transition: "background-color 0.15s ease",
+              display: "inline-flex",
+              alignItems: "center",
+              gap: "8px",
+              opacity: selectedDatasets.length === 0 ? 0.65 : 1
+            }}
+            title={selectedDatasets.length === 0 ? "No datasets selected" : "Clear all dataset selections"}
+          >
+            <FiX size={16} />
+            Clear Selections
           </button>
 
           <button
@@ -645,6 +802,7 @@ export default class DatasetLoadingTable extends React.Component {
         >
           Number of clonal families loaded: {loadedClonalFamilies}
         </div>
+        {loadedClonalFamilies > 0 && this.renderLoadedDatasetsList(allDatasetsToUse)}
         {loadedClonalFamilies > 0 && this.renderFieldSummary(allDatasetsToUse)}
         {loadedClonalFamilies === 0 && (
           <div

--- a/src/components/explorer/DatasetLoadingTable.js
+++ b/src/components/explorer/DatasetLoadingTable.js
@@ -218,6 +218,9 @@ export default class DatasetLoadingTable extends React.Component {
     if (loadedDatasets.length === 0) return null;
 
     // Resolve metadata for each loaded dataset (includes builtins/defaults)
+    const datasetsWithoutMetadata = loadedDatasets
+      .filter((ds) => !ds.field_metadata)
+      .map((ds) => ds.name || ds.dataset_id);
     const resolvedDatasets = loadedDatasets.map((ds) => ({
       name: ds.name || ds.dataset_id,
       metadata: resolveFieldMetadata(ds.field_metadata || null)
@@ -269,6 +272,22 @@ export default class DatasetLoadingTable extends React.Component {
           fontSize: 12
         }}
       >
+        {datasetsWithoutMetadata.length > 0 && (
+          <div
+            style={{
+              marginBottom: 8,
+              padding: "6px 10px",
+              backgroundColor: "#fff3cd",
+              border: "1px solid #ffc107",
+              borderRadius: 4,
+              color: "#856404",
+              fontSize: 11
+            }}
+          >
+            <strong>⚠ No field metadata provided:</strong> {datasetsWithoutMetadata.join(", ")}. Falling back to default
+            fields.
+          </div>
+        )}
         <div style={{ display: "flex", justifyContent: "space-between", alignItems: "center", marginBottom: 6 }}>
           <span style={{ fontWeight: "bold", fontSize: 13 }}>
             Available Fields ({totalDatasets} dataset{totalDatasets > 1 ? "s" : ""})

--- a/src/components/explorer/app.js
+++ b/src/components/explorer/app.js
@@ -44,39 +44,45 @@ const mapStateToProps = (state) => {
   return { selectedFamily, nClonalFamiliesBrushed, nClonalFamiliesTotal, nClonalFamiliesAll };
 };
 
+const notificationBoxStyle = (isEmpty) => ({
+  marginTop: "10px",
+  marginBottom: "10px",
+  padding: "12px",
+  backgroundColor: isEmpty ? "#f8d7da" : "#d4edda",
+  border: isEmpty ? "1px solid #dc3545" : "1px solid #28a745",
+  borderRadius: "4px",
+  color: isEmpty ? "#721c24" : "#155724",
+  fontSize: "14px",
+  textAlign: "center",
+  fontWeight: "bold"
+});
+
+/**
+ * Live count of clonal families that passed the active filters. Red when the
+ * filters exclude everything, green otherwise. Pass `onlyWhenFiltered` to hide
+ * when no filters are active (i.e. nothing has been filtered out).
+ */
+const FilterPassedBar = connect((state) => ({
+  nClonalFamiliesTotal: clonalFamiliesSelectors.getAvailableClonalFamilies(state).length,
+  nClonalFamiliesAll: clonalFamiliesSelectors.getAllClonalFamilies(state).length
+}))(({ nClonalFamiliesTotal, nClonalFamiliesAll, onlyWhenFiltered }) => {
+  const nFiltered = nClonalFamiliesAll - nClonalFamiliesTotal;
+  if (onlyWhenFiltered && nFiltered === 0) return null;
+  return (
+    <div style={notificationBoxStyle(nClonalFamiliesTotal === 0)}>
+      Number of clonal families passed filter: {nClonalFamiliesTotal} out of {nClonalFamiliesAll}
+    </div>
+  );
+});
+
 @connect(mapStateToProps)
 class SelectedFamiliesSummary extends React.Component {
   render() {
-    const { nClonalFamiliesBrushed, nClonalFamiliesTotal, nClonalFamiliesAll } = this.props;
-    const nFiltered = nClonalFamiliesAll - nClonalFamiliesTotal;
-    const showFilterInfo = nFiltered > 0;
-    const infoBoxStyle = {
-      marginTop: "10px",
-      marginBottom: "10px",
-      padding: "12px",
-      backgroundColor: "#d4edda",
-      border: "1px solid #28a745",
-      borderRadius: "4px",
-      color: "#155724",
-      fontSize: "14px",
-      textAlign: "center",
-      fontWeight: "bold"
-    };
+    const { nClonalFamiliesBrushed, nClonalFamiliesTotal } = this.props;
     return (
       <div>
-        {showFilterInfo && (
-          <div style={infoBoxStyle}>
-            Number of clonal families passed filter: {nClonalFamiliesTotal} out of {nClonalFamiliesAll}
-          </div>
-        )}
-        <div
-          style={{
-            ...infoBoxStyle,
-            backgroundColor: nClonalFamiliesBrushed === 0 ? "#f8d7da" : "#d4edda",
-            border: nClonalFamiliesBrushed === 0 ? "1px solid #dc3545" : "1px solid #28a745",
-            color: nClonalFamiliesBrushed === 0 ? "#721c24" : "#155724"
-          }}
-        >
+        <FilterPassedBar onlyWhenFiltered />
+        <div style={notificationBoxStyle(nClonalFamiliesBrushed === 0)}>
           Number of clonal families currently selected: {nClonalFamiliesBrushed} out of {nClonalFamiliesTotal}
         </div>
       </div>
@@ -189,6 +195,30 @@ function DatasetsSection({ sectionRef, availableDatasets, dispatch }) {
                   unstar all currently visible datasets. Use &quot;Clear Stars&quot; to remove all stars
                 </li>
               </ul>
+              <strong>Available Data Fields:</strong> Once datasets are loaded, a panel below the table summarizes the
+              family-level, node, branch, and mutation fields provided by those datasets. Each field is marked with its
+              display mode:
+              <ul style={{ marginTop: "5px", paddingLeft: "20px", marginBottom: "10px" }}>
+                <li>
+                  <strong>🟢 dropdown:</strong> Available in scatterplot and tree encoding selectors
+                </li>
+                <li>
+                  <strong>🟡 tooltip:</strong> Shown on hover/in detail views but not directly selectable
+                </li>
+                <li>
+                  <strong>🔴 skip:</strong> Hidden from the UI
+                </li>
+                <li>
+                  <strong>Show Only Shared / Show All Data Fields:</strong> When two or more datasets are loaded, toggle
+                  between showing only fields common to every loaded dataset and showing every field from any loaded
+                  dataset. In &quot;Show All&quot; mode, fields that are not present in every dataset are marked with a
+                  † and hovering reveals which datasets contain them
+                </li>
+                <li>
+                  <strong>Missing field metadata:</strong> Datasets without explicit field metadata will display a
+                  warning and fall back to default fields
+                </li>
+              </ul>
               <strong>Export:</strong> Click &quot;Download Table as CSV&quot; to export the current table view (with
               applied filters and sorting) to a CSV file.
               <br />
@@ -205,28 +235,83 @@ function DatasetsSection({ sectionRef, availableDatasets, dispatch }) {
 }
 
 /**
- * Clonal Families section — scatterplot with filters and help text.
+ * Filters section — collapsible filter panel with help text.
+ */
+function FiltersSection({ sectionRef }) {
+  return (
+    <div ref={sectionRef} style={sectionStyle}>
+      <CollapsibleSection titleText="Filters" defaultOpen={false}>
+        <CollapseHelpTitle
+          titleText="Filters"
+          helpText={
+            <div>
+              The Filters section restricts which clonal families are displayed across the Clonal Family Scatterplot and
+              Clonal Family Selection Table. Filter by any family-level categorical metric or metadata field available
+              in the loaded datasets.
+              <br />
+              <br />
+              <strong>Adding filters:</strong>
+              <ul style={{ marginTop: "5px", paddingLeft: "20px", marginBottom: "10px" }}>
+                <li>
+                  <strong>Expand a field:</strong> Click a field name to reveal the list of values observed across
+                  loaded datasets
+                </li>
+                <li>
+                  <strong>Select values:</strong> Check one or more boxes to keep only clonal families matching those
+                  values. Multiple selections within a field are combined with OR; different fields are combined with
+                  AND
+                </li>
+                <li>
+                  <strong>Multiple datasets:</strong> Values from all loaded datasets appear together, so you can filter
+                  comparatively across samples or subjects
+                </li>
+              </ul>
+              <strong>Removing filters:</strong>
+              <ul style={{ marginTop: "5px", paddingLeft: "20px", marginBottom: "10px" }}>
+                <li>
+                  <strong>Uncheck a value:</strong> Re-open the field and uncheck a value to drop it from the filter
+                </li>
+                <li>
+                  <strong>Remove a field:</strong> Click the × on an active filter chip at the top of the panel to clear
+                  that field&apos;s selections entirely
+                </li>
+                <li>
+                  <strong>Clear all:</strong> Click &quot;Clear all&quot; next to the chips to reset every active filter
+                  at once
+                </li>
+              </ul>
+            </div>
+          }
+        />
+        <FilterPassedBar />
+        <FilterPanel />
+      </CollapsibleSection>
+    </div>
+  );
+}
+
+/**
+ * Clonal Family Scatterplot section — scatterplot with help text.
  */
 function ClonalFamiliesSection({ sectionRef }) {
   return (
     <div ref={sectionRef} style={sectionStyle}>
-      <CollapsibleSection titleText="Clonal Families">
+      <CollapsibleSection titleText="Clonal Family Scatterplot">
         <CollapseHelpTitle
-          titleText="Clonal Families"
+          titleText="Clonal Family Scatterplot"
           helpText={
             <div>
-              The Clonal Families section represents each clonal family as a point in a scatterplot. Each point
+              The Clonal Family Scatterplot represents each clonal family as a point in a scatterplot. Each point
               corresponds to a single clonal family, with axes, size, color, and shape customizable to display different
               family-level metrics and metadata. For paired heavy/light chain data, each chain is represented as a
               separate data point. Interact with the plot by clicking individual points or dragging to brush-select
-              multiple clones, which filters the clonal families displayed in the Selected Clonal Families table below.
+              multiple clones, which filters the clonal families displayed in the Clonal Family Selection Table below.
               See the <a href="https://github.com/matsengrp/olmsted#readme">README</a> to learn more about AIRR, PCP, or
               Olmsted data schemas and field descriptions.
               <br />
               <br />
-              <strong>Filters:</strong> Use the &quot;Filters&quot; panel below to restrict which clonal families are
-              displayed. Filter by locus (IGH, IGK, IGL), subject, sample, V gene, J gene, or dataset. Multiple values
-              can be selected for each filter field. Active filters are shown as chips that can be individually removed.
+              <strong>Filters:</strong> Use the &quot;Filters&quot; section above to restrict which clonal families are
+              displayed.
               <br />
               <br />
               <strong>Control Modes:</strong> The scatterplot has two interaction modes accessible via buttons in the
@@ -309,9 +394,6 @@ function ClonalFamiliesSection({ sectionRef }) {
             </div>
           }
         />
-        <CollapsibleSection titleText="Filters" defaultOpen={false}>
-          <FilterPanel />
-        </CollapsibleSection>
         <SelectedFamiliesSummary />
         <ClonalFamiliesViz />
       </CollapsibleSection>
@@ -320,17 +402,17 @@ function ClonalFamiliesSection({ sectionRef }) {
 }
 
 /**
- * Selected Clonal Families section — table with help text.
+ * Clonal Family Selection Table section — table with help text.
  */
 function SelectedFamiliesSection({ sectionRef }) {
   return (
     <div ref={sectionRef} style={{ paddingBottom: 40, ...sectionStyle }}>
-      <CollapsibleSection titleText="Selected Clonal Families">
+      <CollapsibleSection titleText="Clonal Family Selection Table">
         <CollapseHelpTitle
-          titleText="Selected Clonal Families"
+          titleText="Clonal Family Selection Table"
           helpText={
             <div>
-              The Selected Clonal Families table displays the full collection or selected subset of clonal families
+              The Clonal Family Selection Table displays the full collection or selected subset of clonal families
               (based on scatterplot selection). Each row represents one clonal family and includes:
               <ul style={{ marginTop: "5px", paddingLeft: "20px", marginBottom: "10px" }}>
                 <li>
@@ -385,7 +467,7 @@ function SelectedFamiliesSection({ sectionRef }) {
               <br />
               <br />
               When you select a clonal family from the table, its phylogenetic tree and alignment are displayed below in
-              the Clonal Family Details section. For paired heavy/light chain data, trees for both chains will be
+              the Clonal Family Phylogeny section. For paired heavy/light chain data, trees for both chains will be
               available.
             </div>
           }
@@ -418,6 +500,7 @@ class App extends React.Component {
     // Refs for section visibility tracking
     this.sectionRefs = {
       datasets: React.createRef(),
+      filters: React.createRef(),
       clonalFamilies: React.createRef(),
       selectedClonalFamilies: React.createRef(),
       clonalFamilyDetails: React.createRef(),
@@ -425,9 +508,10 @@ class App extends React.Component {
     };
     this.sectionNames = {
       datasets: "Datasets",
-      clonalFamilies: "Clonal Families",
-      selectedClonalFamilies: "Selected Clonal Families",
-      clonalFamilyDetails: "Clonal Family Details",
+      filters: "Filters",
+      clonalFamilies: "Clonal Family Scatterplot",
+      selectedClonalFamilies: "Clonal Family Selection Table",
+      clonalFamilyDetails: "Clonal Family Phylogeny",
       ancestralSequences: "Ancestral Sequences"
     };
   }
@@ -635,13 +719,14 @@ class App extends React.Component {
                 availableDatasets={availableDatasets}
                 dispatch={dispatch}
               />
+              {loadedClonalFamilies > 0 && <FiltersSection sectionRef={this.sectionRefs.filters} />}
               {loadedClonalFamilies > 0 && <ClonalFamiliesSection sectionRef={this.sectionRefs.clonalFamilies} />}
               {loadedClonalFamilies > 0 && (
                 <SelectedFamiliesSection sectionRef={this.sectionRefs.selectedClonalFamilies} />
               )}
               {selectedFamily && loadedClonalFamilies > 0 && (
                 <div ref={this.sectionRefs.clonalFamilyDetails} style={sectionStyle}>
-                  <CollapsibleSection titleText="Clonal Family Details">
+                  <CollapsibleSection titleText="Clonal Family Phylogeny">
                     <TreeViz availableHeight={availableHeight} />
                   </CollapsibleSection>
                 </div>

--- a/src/components/explorer/app.js
+++ b/src/components/explorer/app.js
@@ -16,6 +16,7 @@ import { NAV_BAR_HEIGHT } from "../framework/nav-bar";
 import ConfigModal from "../config/ConfigModal";
 import FilterPanel from "./FilterPanel";
 import { VegaViewProvider } from "../config/VegaViewContext";
+import { DISPLAY_MODE_ICONS } from "../../constants/fieldDefaults";
 
 // STYLES
 const PADDING_FRACTION = 0.03;
@@ -200,13 +201,15 @@ function DatasetsSection({ sectionRef, availableDatasets, dispatch }) {
               display mode:
               <ul style={{ marginTop: "5px", paddingLeft: "20px", marginBottom: "10px" }}>
                 <li>
-                  <strong>🟢 dropdown:</strong> Available in scatterplot and tree encoding selectors
+                  <strong>{DISPLAY_MODE_ICONS.dropdown} dropdown:</strong> Available in scatterplot and tree encoding
+                  selectors
                 </li>
                 <li>
-                  <strong>🟡 tooltip:</strong> Shown on hover/in detail views but not directly selectable
+                  <strong>{DISPLAY_MODE_ICONS.tooltip} tooltip:</strong> Shown on hover/in detail views but not directly
+                  selectable
                 </li>
                 <li>
-                  <strong>🔴 skip:</strong> Hidden from the UI
+                  <strong>{DISPLAY_MODE_ICONS.skip} skip:</strong> Hidden from the UI
                 </li>
                 <li>
                   <strong>Show Only Shared / Show All Data Fields:</strong> When two or more datasets are loaded, toggle
@@ -467,8 +470,8 @@ function SelectedFamiliesSection({ sectionRef }) {
               <br />
               <br />
               When you select a clonal family from the table, its phylogenetic tree and alignment are displayed below in
-              the Clonal Family Phylogeny section. For paired heavy/light chain data, trees for both chains will be
-              available.
+              the Clonal Family Tree & Alignment section. For paired heavy/light chain data, trees for both chains will
+              be available.
             </div>
           }
         />
@@ -511,7 +514,7 @@ class App extends React.Component {
       filters: "Filters",
       clonalFamilies: "Clonal Family Scatterplot",
       selectedClonalFamilies: "Clonal Family Selection Table",
-      clonalFamilyDetails: "Clonal Family Phylogeny",
+      clonalFamilyDetails: "Clonal Family Tree & Alignment",
       ancestralSequences: "Ancestral Sequences"
     };
   }
@@ -726,7 +729,7 @@ class App extends React.Component {
               )}
               {selectedFamily && loadedClonalFamilies > 0 && (
                 <div ref={this.sectionRefs.clonalFamilyDetails} style={sectionStyle}>
-                  <CollapsibleSection titleText="Clonal Family Phylogeny">
+                  <CollapsibleSection titleText="Clonal Family Tree & Alignment">
                     <TreeViz availableHeight={availableHeight} />
                   </CollapsibleSection>
                 </div>

--- a/src/components/explorer/lineage.js
+++ b/src/components/explorer/lineage.js
@@ -282,8 +282,8 @@ class Lineage extends React.Component {
                 <div>
                   The Ancestral Sequences section displays an alignment showing the mutational path from the naive
                   sequence to the selected sequence. Each row represents a node along the lineage, with mutations
-                  highlighted using the same color scheme as the Clonal Family Phylogeny alignment view. CDR regions
-                  (CDR1, CDR2, CDR3) are marked with colored background bars.
+                  highlighted using the same color scheme as the Clonal Family Tree & Alignment view. CDR regions (CDR1,
+                  CDR2, CDR3) are marked with colored background bars.
                   <br />
                   <br />
                   <strong>Paired Heavy/Light Chain Data:</strong> For paired data, a Chain dropdown menu appears below,
@@ -301,8 +301,8 @@ class Lineage extends React.Component {
                     </li>
                   </ul>
                   <strong>Surprise Score Coloring:</strong> When the dataset includes per-mutation surprise scores, the
-                  &quot;Color by surprise score&quot; toggle (enabled in the Clonal Family Phylogeny view above) also
-                  applies here. Scored mutations are colored using an orange heat scale; unscored mutations become
+                  &quot;Color by surprise score&quot; toggle (enabled in the Clonal Family Tree & Alignment view above)
+                  also applies here. Scored mutations are colored using an orange heat scale; unscored mutations become
                   invisible. A surprise score legend appears on the right when active.
                   <br />
                   <br />

--- a/src/components/explorer/lineage.js
+++ b/src/components/explorer/lineage.js
@@ -69,6 +69,9 @@ const mapStateToProps = (state) => {
     lineageShowEntire: state.clonalFamilies.lineageShowEntire,
     lineageShowBorders: state.clonalFamilies.lineageShowBorders,
     lineageChain: state.clonalFamilies.lineageChain,
+    // Subtree focus (shared with the Phylogeny view)
+    subtreeRoot: state.clonalFamilies.subtreeRoot,
+    treatSubtreeAsRoot: state.clonalFamilies.treatSubtreeAsRoot,
     dataFields: getSelectedDatasetFields(state)
   };
 };
@@ -218,7 +221,9 @@ class Lineage extends React.Component {
       lightTree,
       lineageShowEntire,
       lineageShowBorders,
-      lineageChain
+      lineageChain,
+      subtreeRoot,
+      treatSubtreeAsRoot
     } = this.props;
     const showEntireLineage = lineageShowEntire;
     const showMutationBorders = lineageShowBorders;
@@ -239,9 +244,13 @@ class Lineage extends React.Component {
         }
       }
 
-      // Compute lineage data with the option to show all nodes
-      // No chain parameter needed - the tree already has the correct chain's data
-      const lineageData = treesSelector.computeLineageDataWithOptions(treeToUse, seqToUse, showEntireLineage);
+      // Compute lineage data. If the Phylogeny view has a focused subtree AND
+      // treat-as-root is on, compute relative to the subtree root so mutations
+      // and the lineage path mirror the Phylogeny view's reference.
+      const lineageData =
+        subtreeRoot && treatSubtreeAsRoot
+          ? treesSelector.computeLineageDataRelativeTo(treeToUse, seqToUse, subtreeRoot, showEntireLineage)
+          : treesSelector.computeLineageDataWithOptions(treeToUse, seqToUse, showEntireLineage);
 
       // Check if lineageData is valid (has required properties)
       const hasLineageData = lineageData && lineageData.lineage_alignment && lineageData.download_lineage_seqs;
@@ -273,7 +282,7 @@ class Lineage extends React.Component {
                 <div>
                   The Ancestral Sequences section displays an alignment showing the mutational path from the naive
                   sequence to the selected sequence. Each row represents a node along the lineage, with mutations
-                  highlighted using the same color scheme as the Clonal Family Details alignment view. CDR regions
+                  highlighted using the same color scheme as the Clonal Family Phylogeny alignment view. CDR regions
                   (CDR1, CDR2, CDR3) are marked with colored background bars.
                   <br />
                   <br />
@@ -292,7 +301,7 @@ class Lineage extends React.Component {
                     </li>
                   </ul>
                   <strong>Surprise Score Coloring:</strong> When the dataset includes per-mutation surprise scores, the
-                  &quot;Color by surprise score&quot; toggle (enabled in the Clonal Family Details view above) also
+                  &quot;Color by surprise score&quot; toggle (enabled in the Clonal Family Phylogeny view above) also
                   applies here. Scored mutations are colored using an orange heat scale; unscored mutations become
                   invisible. A surprise score legend appears on the right when active.
                   <br />

--- a/src/components/explorer/tree.js
+++ b/src/components/explorer/tree.js
@@ -23,6 +23,27 @@ import { CHAIN_TYPES, isBothChainsMode, isStackedMode, isSideBySideMode } from "
 import VegaViewContext from "../config/VegaViewContext";
 import { VegaExportToolbar } from "../util/VegaExportButton";
 
+// Placeholder shown when an ancestral reconstruction method / tree type is blank.
+const UNSPECIFIED_TREE_LABEL = "<unspecified>";
+
+// Build the `key` for a Vega chart so it remounts cleanly when subtree focus
+// or the treat-as-root mode toggles.
+const vegaChartKey = (prefix, subtreeRoot, treatAsRoot) =>
+  `${prefix}-${subtreeRoot || "full"}-${treatAsRoot ? "asroot" : "rel"}`;
+
+// For unpaired families the Chain field is a disabled single-option select.
+// Renders a dropdown locked to the family's actual chain (heavy or light).
+function PinnedChainSelect({ clone }) {
+  const pinnedChain = clonalFamiliesSelectors.getCloneChain(clone);
+  const pinnedValue = pinnedChain === "light" ? CHAIN_TYPES.LIGHT : CHAIN_TYPES.HEAVY;
+  const pinnedLabel = pinnedChain === "light" ? "Light chain only" : "Heavy chain only";
+  return (
+    <select id="chain-select" value={pinnedValue} disabled aria-label="Chain selection">
+      <option value={pinnedValue}>{pinnedLabel}</option>
+    </select>
+  );
+}
+
 /**
  * Normalize nodes to an array (they may be an object keyed by sequence_id or an array).
  */
@@ -57,14 +78,9 @@ const applySubtreeFilter = (nodes, alignment, leavesCount, subtreeRoot, getSubtr
 
   if (treatAsRoot) {
     const rootNode = filteredNodes.find((n) => n.sequence_id === subtreeRoot);
-    if (rootNode && rootNode.sequence_alignment_aa) {
-      // Regenerate alignment rows using the subtree root as the naive reference.
-      const renderable = filteredNodes.filter((n) => n.type === "root" || n.type === "leaf");
-      const regenerated = treesSelector.createAlignment(
-        rootNode.sequence_alignment_aa,
-        renderable,
-        rootNode.sequence_alignment || null
-      );
+    const renderable = filteredNodes.filter((n) => n.type === "root" || n.type === "leaf");
+    const regenerated = treesSelector.buildSubtreeAlignment(rootNode, renderable);
+    if (regenerated) {
       return { nodes: filteredNodes, alignment: regenerated, leavesCount: filteredCount };
     }
   }
@@ -98,7 +114,7 @@ class TreeHeader extends React.Component {
     return (
       <div>
         <CollapseHelpTitle
-          titleText="Clonal Family Phylogeny"
+          titleText="Clonal Family Tree & Alignment"
           helpText={
             <div>
               For a selected clonal family, its phylogenetic tree is visualized below. Alongside the tree is an
@@ -267,16 +283,7 @@ class TreeHeader extends React.Component {
               <option value={CHAIN_TYPES.BOTH_STACKED}>Both chains (stacked)</option>
             </select>
           ) : (
-            (() => {
-              const pinnedChain = clonalFamiliesSelectors.getCloneChain(selectedFamily);
-              const pinnedValue = pinnedChain === "light" ? CHAIN_TYPES.LIGHT : CHAIN_TYPES.HEAVY;
-              const pinnedLabel = pinnedChain === "light" ? "Light chain only" : "Heavy chain only";
-              return (
-                <select id="chain-select" value={pinnedValue} disabled aria-label="Chain selection">
-                  <option value={pinnedValue}>{pinnedLabel}</option>
-                </select>
-              );
-            })()
+            <PinnedChainSelect clone={selectedFamily} />
           )}
         </div>
         <div style={{ marginTop: "8px" }}>
@@ -292,14 +299,14 @@ class TreeHeader extends React.Component {
                 const typeStr = typeof tree_option.type === "string" ? tree_option.type.trim() : "";
                 return (
                   <option key={tree_option.ident} value={tree_option.ident}>
-                    {typeStr || "<unspecified>"}
+                    {typeStr || UNSPECIFIED_TREE_LABEL}
                   </option>
                 );
               })}
             </select>
           ) : (
             <select id="tree-select" value={tree.ident || ""} disabled aria-label="Ancestral reconstruction method">
-              <option value={tree.ident || ""}>{"<unspecified>"}</option>
+              <option value={tree.ident || ""}>{UNSPECIFIED_TREE_LABEL}</option>
             </select>
           )}
         </div>
@@ -1251,7 +1258,7 @@ class TreeViz extends React.Component {
               <h4 style={{ marginBottom: "5px", marginTop: "10px" }}>Heavy Chain (above) / Light Chain (below)</h4>
               {this.renderSubtreeNav(heavyTree || tree)}
               <VegaChart
-                key={`heavy-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
+                key={vegaChartKey("heavy", subtreeRoot, this.props.treatSubtreeAsRoot)}
                 onNewView={(view) => {
                   this.setupHeavyChainSignalSync(view);
                   view.addSignalListener("pts_tuple", (name, node) => {
@@ -1268,7 +1275,7 @@ class TreeViz extends React.Component {
               />
               {lightTree ? (
                 <VegaChart
-                  key={`light-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
+                  key={vegaChartKey("light", subtreeRoot, this.props.treatSubtreeAsRoot)}
                   onNewView={(view) => {
                     this.setupLightChainSignalSync(view, 0.4);
                     view.addSignalListener("pts_tuple", (name, node) => {
@@ -1371,7 +1378,7 @@ class TreeViz extends React.Component {
                   <h4 style={{ marginBottom: "5px", marginTop: "10px" }}>{chainLabel}</h4>
                   {this.renderSubtreeNav(tree)}
                   <VegaChart
-                    key={`tree-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
+                    key={vegaChartKey("tree", subtreeRoot, this.props.treatSubtreeAsRoot)}
                     onNewView={(view) => this.setupSingleChainView(view, dispatchSelectedSeq)}
                     onError={this.handleVegaError}
                     data={this.treeDataFromProps()}
@@ -1384,7 +1391,7 @@ class TreeViz extends React.Component {
             <div>
               {this.renderSubtreeNav(tree)}
               <VegaChart
-                key={`tree-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
+                key={vegaChartKey("tree", subtreeRoot, this.props.treatSubtreeAsRoot)}
                 onNewView={(view) => this.setupSingleChainView(view, dispatchSelectedSeq)}
                 onError={this.handleVegaError}
                 data={this.tempVegaData}

--- a/src/components/explorer/tree.js
+++ b/src/components/explorer/tree.js
@@ -35,22 +35,42 @@ const normalizeNodes = (nodes) => {
  * Filter tree data to a subtree rooted at the given node.
  * The subtree root is re-parented to null and given type "root".
  *
+ * When treatAsRoot is true, the alignment is regenerated with the subtree
+ * root's sequence as the new reference (naive), so mutations in the viz
+ * are shown relative to the subtree root instead of the original naive.
+ *
  * @param {Object[]} nodes - Full tree nodes array
  * @param {Object[]} alignment - Full alignment records
  * @param {number} leavesCount - Original leaves count
  * @param {string} subtreeRoot - sequence_id of the subtree root
  * @param {Function} getSubtreeNodeIds - Function to collect descendant IDs
+ * @param {boolean} treatAsRoot - recompute alignment relative to subtree root
  * @returns {{ nodes: Object[], alignment: Object[], leavesCount: number }}
  */
-const applySubtreeFilter = (nodes, alignment, leavesCount, subtreeRoot, getSubtreeNodeIds) => {
+const applySubtreeFilter = (nodes, alignment, leavesCount, subtreeRoot, getSubtreeNodeIds, treatAsRoot = false) => {
   if (!subtreeRoot || !nodes) return { nodes, alignment, leavesCount };
   const subtreeIds = getSubtreeNodeIds(nodes, subtreeRoot);
   const filteredNodes = nodes
     .filter((n) => subtreeIds.has(n.sequence_id))
     .map((n) => (n.sequence_id === subtreeRoot ? { ...n, parent: null, type: "root" } : n));
+  const filteredCount = filteredNodes.filter((n) => n.type === "root" || n.type === "leaf").length;
+
+  if (treatAsRoot) {
+    const rootNode = filteredNodes.find((n) => n.sequence_id === subtreeRoot);
+    if (rootNode && rootNode.sequence_alignment_aa) {
+      // Regenerate alignment rows using the subtree root as the naive reference.
+      const renderable = filteredNodes.filter((n) => n.type === "root" || n.type === "leaf");
+      const regenerated = treesSelector.createAlignment(
+        rootNode.sequence_alignment_aa,
+        renderable,
+        rootNode.sequence_alignment || null
+      );
+      return { nodes: filteredNodes, alignment: regenerated, leavesCount: filteredCount };
+    }
+  }
+
   // Keep naive (type: "naive") alignment rows — they define the x-axis and gene regions
   const filteredAlignment = alignment.filter((m) => subtreeIds.has(m.seq_id) || m.type === "naive");
-  const filteredCount = filteredNodes.filter((n) => n.type === "root" || n.type === "leaf").length;
   return { nodes: filteredNodes, alignment: filteredAlignment, leavesCount: filteredCount };
 };
 
@@ -78,7 +98,7 @@ class TreeHeader extends React.Component {
     return (
       <div>
         <CollapseHelpTitle
-          titleText={`Clonal Family Details for: "${selectedFamily.sample_id || selectedFamily.subject_id || "sample"} ${selectedFamily.clone_id}"`}
+          titleText="Clonal Family Phylogeny"
           helpText={
             <div>
               For a selected clonal family, its phylogenetic tree is visualized below. Alongside the tree is an
@@ -228,23 +248,14 @@ class TreeHeader extends React.Component {
         />
 
         <div>
-          <span style={{ marginRight: 8 }}>Ancestral reconstruction method:</span>
-          <select
-            id="tree-select"
-            value={tree.ident}
-            onChange={(event) => dispatchSelectedTree(event.target.value, selectedFamily, selectedSeq)}
-            aria-label="Ancestral reconstruction method"
-          >
-            {selectedFamily.trees.map((tree_option) => (
-              <option key={tree_option.ident} value={tree_option.ident}>
-                {tree_option.type || tree_option.tree_id}
-              </option>
-            ))}
-          </select>
+          <span style={{ marginRight: 8 }}>Clonal Family:</span>
+          <span style={{ fontWeight: "bold" }}>
+            {`${selectedFamily.sample_id || selectedFamily.subject_id || "sample"} ${selectedFamily.clone_id}`}
+          </span>
         </div>
-        {selectedFamily.is_paired && (
-          <div style={{ marginTop: "8px" }}>
-            <span style={{ marginRight: 8 }}>Chain:</span>
+        <div style={{ marginTop: "8px" }}>
+          <span style={{ marginRight: 8 }}>Chain:</span>
+          {selectedFamily.is_paired ? (
             <select
               id="chain-select"
               value={selectedChain}
@@ -255,8 +266,43 @@ class TreeHeader extends React.Component {
               <option value={CHAIN_TYPES.LIGHT}>Light chain only</option>
               <option value={CHAIN_TYPES.BOTH_STACKED}>Both chains (stacked)</option>
             </select>
-          </div>
-        )}
+          ) : (
+            (() => {
+              const pinnedChain = clonalFamiliesSelectors.getCloneChain(selectedFamily);
+              const pinnedValue = pinnedChain === "light" ? CHAIN_TYPES.LIGHT : CHAIN_TYPES.HEAVY;
+              const pinnedLabel = pinnedChain === "light" ? "Light chain only" : "Heavy chain only";
+              return (
+                <select id="chain-select" value={pinnedValue} disabled aria-label="Chain selection">
+                  <option value={pinnedValue}>{pinnedLabel}</option>
+                </select>
+              );
+            })()
+          )}
+        </div>
+        <div style={{ marginTop: "8px" }}>
+          <span style={{ marginRight: 8 }}>Ancestral Reconstruction Method:</span>
+          {selectedFamily.trees && selectedFamily.trees.length > 0 ? (
+            <select
+              id="tree-select"
+              value={tree.ident}
+              onChange={(event) => dispatchSelectedTree(event.target.value, selectedFamily, selectedSeq)}
+              aria-label="Ancestral reconstruction method"
+            >
+              {selectedFamily.trees.map((tree_option) => {
+                const typeStr = typeof tree_option.type === "string" ? tree_option.type.trim() : "";
+                return (
+                  <option key={tree_option.ident} value={tree_option.ident}>
+                    {typeStr || "<unspecified>"}
+                  </option>
+                );
+              })}
+            </select>
+          ) : (
+            <select id="tree-select" value={tree.ident || ""} disabled aria-label="Ancestral reconstruction method">
+              <option value={tree.ident || ""}>{"<unspecified>"}</option>
+            </select>
+          )}
+        </div>
       </div>
     );
   }
@@ -287,7 +333,7 @@ const computeCloneVizData = (clone, tree, label = "5p") => {
   return { naiveData, cdrBounds, treeData };
 };
 
-const mapStateToProps = (state) => {
+const baseMapStateToProps = (state) => {
   const selectedFamily = clonalFamiliesSelectors.getSelectedFamily(state);
   const selectedTree = treesSelector.getSelectedTree(state);
   const selectedChain = state.clonalFamilies.selectedChain || "heavy";
@@ -415,6 +461,13 @@ const mapStateToProps = (state) => {
   return { selectedFamily, selectedTree, selectedChain, dataFields };
 };
 
+// Merge shared subtree state from Redux into the rest of the mapped props.
+const mapStateToProps = (state) => ({
+  ...baseMapStateToProps(state),
+  subtreeRoot: state.clonalFamilies.subtreeRoot,
+  treatSubtreeAsRoot: state.clonalFamilies.treatSubtreeAsRoot
+});
+
 // now for the actual component definition
 
 @connect(mapStateToProps, (dispatch) => ({
@@ -429,6 +482,12 @@ const mapStateToProps = (state) => {
   },
   dispatchSelectedChain: (chain) => {
     dispatch(explorerActions.updateSelectedChain(chain));
+  },
+  dispatchSubtreeRoot: (subtreeRoot) => {
+    dispatch(explorerActions.updateSubtreeRoot(subtreeRoot));
+  },
+  dispatchTreatSubtreeAsRoot: (treatAsRoot) => {
+    dispatch(explorerActions.updateTreatSubtreeAsRoot(treatAsRoot));
   }
 }))
 class TreeViz extends React.Component {
@@ -443,8 +502,6 @@ class TreeViz extends React.Component {
       hideControls: false,
       // Vega rendering error message (shown to user)
       vegaError: null,
-      // Subtree focus: sequence_id of the root of the focused subtree (null = full tree)
-      subtreeRoot: null,
       // Whether the user has dismissed the warnings banner for this family
       warningsDismissed: false
     };
@@ -654,10 +711,11 @@ class TreeViz extends React.Component {
    * Focus the tree view on the subtree rooted at the currently selected node.
    */
   focusSubtree() {
-    const { selectedSeq } = this.props;
+    const { selectedSeq, dispatchSubtreeRoot } = this.props;
     if (selectedSeq) {
       this.saveSignals();
-      this.setState({ subtreeRoot: selectedSeq, vegaError: null });
+      this.setState({ vegaError: null });
+      dispatchSubtreeRoot(selectedSeq);
     }
   }
 
@@ -665,8 +723,10 @@ class TreeViz extends React.Component {
    * Reset to showing the full tree.
    */
   resetSubtree() {
+    const { dispatchSubtreeRoot } = this.props;
     this.saveSignals();
-    this.setState({ subtreeRoot: null, vegaError: null });
+    this.setState({ vegaError: null });
+    dispatchSubtreeRoot(null);
   }
 
   /**
@@ -684,7 +744,7 @@ class TreeViz extends React.Component {
    * Get the current effective root — subtreeRoot if focused, otherwise the tree root.
    */
   getEffectiveRootId(nodes) {
-    if (this.state.subtreeRoot) return this.state.subtreeRoot;
+    if (this.props.subtreeRoot) return this.props.subtreeRoot;
     const arr = normalizeNodes(nodes);
     if (arr.length === 0) return null;
     const root = arr.find((n) => !n.parent || n.type === "root");
@@ -695,8 +755,8 @@ class TreeViz extends React.Component {
    * Render the subtree navigation bar (focus/reset buttons + children dropdown).
    */
   renderSubtreeNav(tree) {
-    const { selectedSeq, dispatchSelectedSeq } = this.props;
-    const { subtreeRoot } = this.state;
+    const { selectedSeq, dispatchSelectedSeq, subtreeRoot, treatSubtreeAsRoot, dispatchTreatSubtreeAsRoot } =
+      this.props;
     const nodes = tree ? tree.nodes : null;
     const effectiveRoot = this.getEffectiveRootId(nodes);
     const children = this.getDirectChildren(nodes, effectiveRoot);
@@ -779,6 +839,17 @@ class TreeViz extends React.Component {
               ))}
             </select>
           )}
+          <label
+            style={{ display: "inline-flex", alignItems: "center", gap: 4, cursor: "pointer", fontSize: 12 }}
+            title="When a subtree is focused, use its root as the alignment reference; mutations are shown relative to it, and this cascades into the Ancestral Sequences view."
+          >
+            <input
+              type="checkbox"
+              checked={!!treatSubtreeAsRoot}
+              onChange={(e) => dispatchTreatSubtreeAsRoot(e.target.checked)}
+            />
+            Treat subtree as root
+          </label>
         </div>
       </div>
     );
@@ -951,9 +1022,11 @@ class TreeViz extends React.Component {
     const { selectedFamily, selectedChain, dispatchSelectedChain, tree, selectedSeq, dispatchSelectedSeq } = this.props;
     // When family changes, check if we need to reset chain selection
     if (selectedFamily && selectedFamily !== prevProps.selectedFamily) {
-      // Clear any previous Vega error and subtree focus when switching families
-      if (this.state.vegaError || this.state.subtreeRoot) {
-        this.setState({ vegaError: null, subtreeRoot: null, warningsDismissed: false });
+      // Clear any previous Vega error when switching families.
+      // Subtree focus is reset via the TOGGLE_FAMILY reducer case, so we don't
+      // dispatch it here — but we still clear local view state.
+      if (this.state.vegaError || this.props.subtreeRoot) {
+        this.setState({ vegaError: null, warningsDismissed: false });
       }
       const isBothMode = isBothChainsMode(selectedChain);
       const isLightMode = selectedChain === CHAIN_TYPES.LIGHT;
@@ -999,13 +1072,14 @@ class TreeViz extends React.Component {
     // Only compute remaining data after validation passes
     const cdrBounds = chain === CHAIN_TYPES.HEAVY ? heavyCdrBounds : lightCdrBounds;
 
-    const { subtreeRoot } = this.state;
+    const { subtreeRoot, treatSubtreeAsRoot } = this.props;
     const filtered = applySubtreeFilter(
       tree.nodes,
       tree.tips_alignment,
       tree.leaves_count_incl_naive,
       subtreeRoot,
-      this.getSubtreeNodeIds
+      this.getSubtreeNodeIds,
+      treatSubtreeAsRoot
     );
 
     return {
@@ -1048,15 +1122,15 @@ class TreeViz extends React.Component {
   }
 
   treeDataFromProps() {
-    const { tree, naiveData, cdrBounds, selectedFamily } = this.props;
-    const { subtreeRoot } = this.state;
+    const { tree, naiveData, cdrBounds, selectedFamily, subtreeRoot, treatSubtreeAsRoot } = this.props;
 
     const filtered = applySubtreeFilter(
       tree.nodes,
       tree.tips_alignment,
       tree.leaves_count_incl_naive,
       subtreeRoot,
-      this.getSubtreeNodeIds
+      this.getSubtreeNodeIds,
+      treatSubtreeAsRoot
     );
 
     return {
@@ -1116,7 +1190,8 @@ class TreeViz extends React.Component {
     // Use heavyTree for downloads in both mode, otherwise use tree
     const downloadTree = isBothMode ? heavyTree : tree;
 
-    const { hideControls, vegaError, subtreeRoot } = this.state;
+    const { hideControls, vegaError } = this.state;
+    const { subtreeRoot } = this.props;
 
     return (
       <div ref={this.containerRef}>
@@ -1176,7 +1251,7 @@ class TreeViz extends React.Component {
               <h4 style={{ marginBottom: "5px", marginTop: "10px" }}>Heavy Chain (above) / Light Chain (below)</h4>
               {this.renderSubtreeNav(heavyTree || tree)}
               <VegaChart
-                key={`heavy-${subtreeRoot || "full"}`}
+                key={`heavy-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
                 onNewView={(view) => {
                   this.setupHeavyChainSignalSync(view);
                   view.addSignalListener("pts_tuple", (name, node) => {
@@ -1193,7 +1268,7 @@ class TreeViz extends React.Component {
               />
               {lightTree ? (
                 <VegaChart
-                  key={`light-${subtreeRoot || "full"}`}
+                  key={`light-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
                   onNewView={(view) => {
                     this.setupLightChainSignalSync(view, 0.4);
                     view.addSignalListener("pts_tuple", (name, node) => {
@@ -1296,7 +1371,7 @@ class TreeViz extends React.Component {
                   <h4 style={{ marginBottom: "5px", marginTop: "10px" }}>{chainLabel}</h4>
                   {this.renderSubtreeNav(tree)}
                   <VegaChart
-                    key={`tree-${subtreeRoot || "full"}`}
+                    key={`tree-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
                     onNewView={(view) => this.setupSingleChainView(view, dispatchSelectedSeq)}
                     onError={this.handleVegaError}
                     data={this.treeDataFromProps()}
@@ -1309,7 +1384,7 @@ class TreeViz extends React.Component {
             <div>
               {this.renderSubtreeNav(tree)}
               <VegaChart
-                key={`tree-${subtreeRoot || "full"}`}
+                key={`tree-${subtreeRoot || "full"}-${this.props.treatSubtreeAsRoot ? "asroot" : "rel"}`}
                 onNewView={(view) => this.setupSingleChainView(view, dispatchSelectedSeq)}
                 onError={this.handleVegaError}
                 data={this.tempVegaData}

--- a/src/components/framework/nav-bar.js
+++ b/src/components/framework/nav-bar.js
@@ -79,7 +79,7 @@ class NavBar extends React.Component {
       filters: "Filters",
       clonalFamilies: "Clonal Family Scatterplot",
       selectedClonalFamilies: "Clonal Family Selection Table",
-      clonalFamilyDetails: "Clonal Family Phylogeny",
+      clonalFamilyDetails: "Clonal Family Tree & Alignment",
       ancestralSequences: "Ancestral Sequences"
     };
 

--- a/src/components/framework/nav-bar.js
+++ b/src/components/framework/nav-bar.js
@@ -76,9 +76,10 @@ class NavBar extends React.Component {
     // Find current section by matching the display name
     const sectionNames = {
       datasets: "Datasets",
-      clonalFamilies: "Clonal Families",
-      selectedClonalFamilies: "Selected Clonal Families",
-      clonalFamilyDetails: "Clonal Family Details",
+      filters: "Filters",
+      clonalFamilies: "Clonal Family Scatterplot",
+      selectedClonalFamilies: "Clonal Family Selection Table",
+      clonalFamilyDetails: "Clonal Family Phylogeny",
       ancestralSequences: "Ancestral Sequences"
     };
 

--- a/src/constants/fieldDefaults.js
+++ b/src/constants/fieldDefaults.js
@@ -17,6 +17,13 @@
  */
 export const DEFAULT_DISPLAY = "skip";
 
+/** Icon rendered next to a field label based on its display mode. */
+export const DISPLAY_MODE_ICONS = {
+  dropdown: "🟢",
+  tooltip: "🟡",
+  skip: "🔴"
+};
+
 // ============================================================
 // Clone / Family level
 // ============================================================

--- a/src/reducers/clonalFamilies.js
+++ b/src/reducers/clonalFamilies.js
@@ -27,6 +27,11 @@ const initialState = {
   lineageShowEntire: false,
   lineageShowBorders: false,
   lineageChain: "heavy",
+  // Subtree focus (shared by Phylogeny and Ancestral Sequences views).
+  // subtreeRoot is the sequence_id of the focused subtree's root node, or null.
+  // treatSubtreeAsRoot makes the subtree root the alignment reference (naive).
+  subtreeRoot: null,
+  treatSubtreeAsRoot: false,
   // Current visible section (for nav bar display)
   currentSection: "",
   // Starred families (pinned for easy reference)
@@ -146,7 +151,10 @@ const clonalFamilies = (state = _.clone(initialState), action) => {
     case types.TOGGLE_FAMILY: {
       const updates = {
         selectedFamily: action.family_ident,
-        selectedSeq: {}
+        selectedSeq: {},
+        // Subtree focus is per-family; clear it on family change.
+        subtreeRoot: null,
+        treatSubtreeAsRoot: false
       };
       // action.updateBrushSelection specifies whether we would like to
       // include just this family in our brush selection
@@ -180,6 +188,14 @@ const clonalFamilies = (state = _.clone(initialState), action) => {
     }
     case types.UPDATE_LINEAGE_CHAIN: {
       return { ...state, lineageChain: action.chain };
+    }
+    case types.UPDATE_SUBTREE_ROOT: {
+      // Preserve treatSubtreeAsRoot across focus/unfocus so users can
+      // pre-select the preference before focusing a subtree.
+      return { ...state, subtreeRoot: action.subtreeRoot };
+    }
+    case types.UPDATE_TREAT_SUBTREE_AS_ROOT: {
+      return { ...state, treatSubtreeAsRoot: action.treatAsRoot };
     }
     case types.UPDATE_CURRENT_SECTION: {
       return { ...state, currentSection: action.section };

--- a/src/reducers/clonalFamilies.js
+++ b/src/reducers/clonalFamilies.js
@@ -189,9 +189,10 @@ const clonalFamilies = (state = _.clone(initialState), action) => {
     case types.UPDATE_LINEAGE_CHAIN: {
       return { ...state, lineageChain: action.chain };
     }
+    // Note: UPDATE_SUBTREE_ROOT intentionally does not touch treatSubtreeAsRoot
+    // so users can pre-select the preference before focusing a subtree and have
+    // it persist across focus/unfocus.
     case types.UPDATE_SUBTREE_ROOT: {
-      // Preserve treatSubtreeAsRoot across focus/unfocus so users can
-      // pre-select the preference before focusing a subtree.
       return { ...state, subtreeRoot: action.subtreeRoot };
     }
     case types.UPDATE_TREAT_SUBTREE_AS_ROOT: {

--- a/src/selectors/trees.js
+++ b/src/selectors/trees.js
@@ -447,9 +447,19 @@ export const computeLineageDataWithOptions = (tree, seq, includeAllNodes) => {
   return computeLineageData(tree, seq, includeAllNodes);
 };
 
-// Expose the alignment builder so consumers (e.g. subtree focus mode) can
-// recompute tips_alignment / lineage_alignment against a non-naive reference.
-export { createAlignment, followLineage };
+/**
+ * Regenerate an alignment using a given node's sequence as the naive reference.
+ * Used by the subtree focus "treat as root" mode so the Phylogeny view can
+ * show mutations relative to the subtree root rather than the original naive.
+ *
+ * @param {Object} rootNode - node whose sequence_alignment_aa becomes the reference
+ * @param {Object[]} renderableNodes - nodes to include in the alignment (root + leaves)
+ * @returns {Object[]|null} alignment rows, or null if the root lacks an AA sequence
+ */
+export const buildSubtreeAlignment = (rootNode, renderableNodes) => {
+  if (!rootNode || !rootNode.sequence_alignment_aa) return null;
+  return createAlignment(rootNode.sequence_alignment_aa, renderableNodes, rootNode.sequence_alignment || null);
+};
 
 /**
  * Recompute a lineage using a specific node as the reference (naive) sequence.

--- a/src/selectors/trees.js
+++ b/src/selectors/trees.js
@@ -296,14 +296,16 @@ const ensureSingleRoot = (nodes) => {
     timepoint_multiplicities: []
   };
 
-  // Re-parent all original roots (including empty placeholders) to synthetic root
-  // Then filter out empty placeholders since they add no value
+  // Re-parent all original roots (including empty placeholders) to synthetic root.
+  // Demote them to "node" so downstream code that treats type === "root" as the
+  // single naive row does not generate a duplicate naive alignment row per root.
+  // Also filter out empty placeholders since they add no value.
   const emptyIds = new Set(emptyRoots.map((n) => n.sequence_id));
   const modifiedNodes = nodes
     .filter((n) => !emptyIds.has(n.sequence_id))
     .map((n) => {
       if (!n.parent) {
-        return { ...n, parent: SYNTHETIC_ROOT_ID };
+        return { ...n, parent: SYNTHETIC_ROOT_ID, type: "node" };
       }
       return n;
     });
@@ -443,4 +445,47 @@ export const getLineageData = createSelector([getSelectedTree, getSelectedSeq], 
 // Export the function for direct use with options
 export const computeLineageDataWithOptions = (tree, seq, includeAllNodes) => {
   return computeLineageData(tree, seq, includeAllNodes);
+};
+
+// Expose the alignment builder so consumers (e.g. subtree focus mode) can
+// recompute tips_alignment / lineage_alignment against a non-naive reference.
+export { createAlignment, followLineage };
+
+/**
+ * Recompute a lineage using a specific node as the reference (naive) sequence.
+ * Used by subtree focus "treat as root" mode so the lineage alignment shows
+ * mutations relative to the subtree root rather than the original naive.
+ *
+ * @param {Object} tree - The tree (with .nodes)
+ * @param {Object} seq - The selected leaf sequence
+ * @param {string} referenceSeqId - sequence_id of the node to use as naive
+ * @param {boolean} includeAllNodes - include all intermediate nodes
+ * @returns {Object} tree data with lineage_alignment/download_lineage_seqs overridden
+ */
+export const computeLineageDataRelativeTo = (tree, seq, referenceSeqId, includeAllNodes = false) => {
+  if (!tree) return {};
+  const treeData = _.clone(tree);
+  if (treeData.nodes) {
+    const normalized = normalizeTreeNodes(treeData.nodes);
+    treeData.nodes = normalized.nodes;
+  }
+  if (!treeData.nodes || treeData.nodes.length === 0 || _.isEmpty(seq)) return treeData;
+  const data = treeData.nodes.slice(0);
+  const reference = _.find(data, { sequence_id: referenceSeqId });
+  if (!reference || !reference.sequence_alignment_aa) {
+    // Reference missing — fall back to the natural lineage computation.
+    return computeLineageData(tree, seq, includeAllNodes);
+  }
+  const lineage = followLineage(data, seq, reference, includeAllNodes);
+  // Mark the reference node as naive-equivalent for createAlignment so it
+  // generates a naive row from its own sequence.
+  const lineageAsRoot = lineage.map((n) => (n.sequence_id === referenceSeqId ? { ...n, type: "root" } : n));
+  treeData.download_lineage_seqs = lineage;
+  treeData.lineage_alignment = createAlignment(
+    reference.sequence_alignment_aa,
+    lineageAsRoot,
+    reference.sequence_alignment || null
+  );
+  treeData.lineage_seq_counter = lineage.length;
+  return treeData;
 };


### PR DESCRIPTION
## Summary

Reorganizes the Explorer UI around what each section shows, adds a subtree-as-root focus mode, and surfaces dataset/metadata context the user previously had to infer.

### Section reorganization
- **Filters** split into its own top-level section (between Datasets and the scatterplot), with a dedicated help panel and a live "clonal families passed filter" banner that turns red when filters exclude everything.
- Renamed sections so each header names its view type:
  - Clonal Families → **Clonal Family Scatterplot**
  - Selected Clonal Families → **Clonal Family Selection Table**
  - Clonal Family Details → **Clonal Family Phylogeny**

### Datasets / metadata surfacing
- Warning banner above "Available Data Fields" when a loaded dataset has no `field_metadata` (falls back to defaults).
- New "Active Datasets" subsection above Available Data Fields listing each loaded dataset by name and clonal family count.
- Union/Intersection toggle ("Show Only Shared" / "Show All Data Fields") for the field listing when 2+ datasets are loaded; partial fields marked with `†` in union mode.
- Field display-mode legend updated to green/yellow/red dots (🟢 dropdown, 🟡 tooltip, 🔴 skip).

### Dataset loading UX
- "Update Visualization" button reads **"Visualization Up-to-Date"** when no changes are pending (greyed out).
- Selections no longer auto-clear after an update, so the button settles into the up-to-date state until the user interacts with the table.
- New **Clear Selections** button between Update Visualization and Manage Datasets, disabled when no selections are made.

### Clonal Family Phylogeny header
- Family identifier pulled out of the section title into a read-only **Clonal Family** field below.
- **Chain** field is always visible — pinned (disabled) to the family's locus for unpaired data, a dropdown for paired.
- **Ancestral Reconstruction Method** dropdown renders `<unspecified>` for blank `type` values, and falls back to a single `<unspecified>` option when a tree has no method metadata at all.

### Subtree-as-root focus mode
- New checkbox **"Treat subtree as root"** next to the Focus Subtree controls. Always visible (so users can pre-select the preference).
- When enabled, the Phylogeny alignment is regenerated using the subtree root's sequence as the naive reference, and the Ancestral Sequences lineage view cascades automatically via a new `computeLineageDataRelativeTo` selector.
- Subtree state (`subtreeRoot`, `treatSubtreeAsRoot`) promoted to Redux so both views stay in sync; both fields reset on family change.

### Bug fix
- In `ensureSingleRoot`, original subtree roots under a synthetic root are now demoted to `type: \"node\"`, fixing a bug where each produced a duplicate naive alignment row stacked on top of the others.

## Test plan
- [x] Load a dataset without field metadata — warning banner appears above Available Data Fields
- [x] Load two datasets — Union/Intersection toggle appears; † marker and hover-dataset-list work in union mode
- [x] Toggle a dataset selection checkbox — button flips from \"Visualization Up-to-Date\" to \"Update Visualization (N changes pending)\"
- [x] Click Clear Selections — checkboxes clear; button disables when no selections
- [x] Verify renamed section headers and nav bar labels
- [x] Focus a subtree → check \"Treat subtree as root\" → confirm naive row swaps to subtree root sequence and mutations recompute; confirm the Ancestral Sequences view mirrors the new reference
- [x] Load a forest tree (multiple root nodes) and verify naive row is not duplicated

🤖 Generated with [Claude Code](https://claude.com/claude-code)