### PR TITLE
Restore .gz upload support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
         "express": "^5.2.1",
         "express-naked-redirect": "^0.1.3",
         "express-static-gzip": "^3.0.0",
+        "fflate": "^0.8.2",
         "js-yaml": "^4.1.1",
         "leaflet": "^1.4.0",
         "linspace": "^1.0.0",
@@ -10321,6 +10322,12 @@
       "engines": {
         "node": "^12.20 || >= 14.13"
       }
+    },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
     },
     "node_modules/file-entry-cache": {
       "version": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "express": "^5.2.1",
     "express-naked-redirect": "^0.1.3",
     "express-static-gzip": "^3.0.0",
+    "fflate": "^0.8.2",
     "js-yaml": "^4.1.1",
     "leaflet": "^1.4.0",
     "linspace": "^1.0.0",

--- a/src/components/splash/fileUpload.js
+++ b/src/components/splash/fileUpload.js
@@ -137,20 +137,13 @@ class FileUpload extends React.Component {
       const fileName = file.name.toLowerCase();
       let fileType = null;
 
-      if (fileName.endsWith(".json")) {
+      if (fileName.endsWith(".json") || fileName.endsWith(".json.gz")) {
         fileType = "consolidated";
-      } else if (fileName.endsWith(".gz")) {
-        // Check the extension before .gz
-        if (fileName.includes(".json.gz")) {
-          fileType = "consolidated";
-          // Note: gzip support would need additional implementation
-          throw new Error("Gzipped files are not yet supported. Please upload uncompressed JSON files.");
-        }
       }
 
       if (!fileType) {
         throw new Error(
-          "Unsupported file type. Please upload olmsted-cli consolidated JSON files (.json). For split files, select all files together (datasets.json, clones.*.json, tree.*.json)."
+          "Unsupported file type. Please upload olmsted-cli consolidated JSON files (.json or .json.gz). For split files, select all files together (datasets.json, clones.*.json, tree.*.json)."
         );
       }
 
@@ -419,7 +412,7 @@ class FileUpload extends React.Component {
           <input
             ref={this.fileInputRef}
             type="file"
-            accept="application/json, .json"
+            accept="application/json, .json, .json.gz, .gz"
             multiple
             style={{ display: "none" }}
             onChange={this.handleFileInputChange.bind(this)}
@@ -531,7 +524,7 @@ class FileUpload extends React.Component {
                     </div>
                     <div style={{ fontSize: 16, color: "#05337f", marginBottom: 15 }}>or click to browse</div>
                     <div style={{ fontSize: 14, color: "#666" }}>
-                      <strong>Supported format:</strong> olmsted-cli consolidated JSON (.json)
+                      <strong>Supported formats:</strong> olmsted-cli consolidated JSON (.json or .json.gz)
                     </div>
                   </div>
                 )}

--- a/src/components/splash/fileUpload.js
+++ b/src/components/splash/fileUpload.js
@@ -151,9 +151,11 @@ class FileUpload extends React.Component {
       this.updateLoadingStatus("Reading and parsing file data...", 25);
       const result = await FileProcessor.processFile(file);
 
-      // Add file size to the first dataset
+      // Add the decompressed payload size to the first dataset. For .json this
+      // matches file.size; for .json.gz it's the gunzipped byte count, which is
+      // the size that's actually loaded into memory and IndexedDB.
       if (result.datasets && result.datasets.length > 0) {
-        result.datasets[0].file_size = file.size;
+        result.datasets[0].file_size = result.dataSize ?? file.size;
       }
 
       // Guard against duplicate uploads (same source id and/or same display

--- a/src/utils/__tests__/fileProcessor.test.js
+++ b/src/utils/__tests__/fileProcessor.test.js
@@ -173,6 +173,21 @@ describe("FileProcessor", () => {
       expect(result.datasets[0].original_filename).toBe("consolidated.json.gz");
     });
 
+    it("reports the decompressed byte count, not the compressed file size", async () => {
+      const file = makeGzFile(validJson, "consolidated.json.gz");
+      const expectedBytes = strToU8(validJson).length;
+      const result = await FileProcessor.processFile(file);
+      // Compression should make the file strictly smaller for non-trivial JSON
+      expect(file.size).toBeLessThan(expectedBytes);
+      expect(result.dataSize).toBe(expectedBytes);
+    });
+
+    it("reports file.size as dataSize for plain .json uploads", async () => {
+      const file = new File([validJson], "consolidated.json", { type: "application/json" });
+      const result = await FileProcessor.processFile(file);
+      expect(result.dataSize).toBe(file.size);
+    });
+
     it("throws a decompression error on malformed gz bytes", async () => {
       const garbage = new Uint8Array([0x1f, 0x8b, 0x00, 0xff, 0xff, 0xff, 0xff]); // bad gzip
       const file = new File([garbage], "broken.json.gz", { type: "application/gzip" });

--- a/src/utils/__tests__/fileProcessor.test.js
+++ b/src/utils/__tests__/fileProcessor.test.js
@@ -1,4 +1,10 @@
+import { gzipSync, strToU8 } from "fflate";
 import FileProcessor from "../fileProcessor";
+
+const makeGzFile = (text, name = "test.json.gz") => {
+  const gz = gzipSync(strToU8(text));
+  return new File([gz], name, { type: "application/gzip" });
+};
 
 describe("FileProcessor", () => {
   describe("isConsolidatedFormat", () => {
@@ -148,6 +154,34 @@ describe("FileProcessor", () => {
 
     it("starts with upload-", () => {
       expect(FileProcessor.generateDatasetId()).toMatch(/^upload-/);
+    });
+  });
+
+  describe("processFile (gzipped)", () => {
+    const validJson = JSON.stringify({
+      metadata: { schema_version: "2.0.0" },
+      datasets: [{ dataset_id: "d1", clone_count: 0, subjects_count: 1 }],
+      clones: { d1: [] },
+      trees: []
+    });
+
+    it("decompresses a .json.gz upload and processes it", async () => {
+      const file = makeGzFile(validJson, "consolidated.json.gz");
+      const result = await FileProcessor.processFile(file);
+      expect(result.datasets).toHaveLength(1);
+      expect(result.datasetId).toMatch(/^upload-/);
+      expect(result.datasets[0].original_filename).toBe("consolidated.json.gz");
+    });
+
+    it("throws a decompression error on malformed gz bytes", async () => {
+      const garbage = new Uint8Array([0x1f, 0x8b, 0x00, 0xff, 0xff, 0xff, 0xff]); // bad gzip
+      const file = new File([garbage], "broken.json.gz", { type: "application/gzip" });
+      await expect(FileProcessor.processFile(file)).rejects.toThrow(/Failed to decompress gzipped file/);
+    });
+
+    it("throws an Invalid JSON error when the decompressed payload is not JSON", async () => {
+      const file = makeGzFile("not json at all", "weird.json.gz");
+      await expect(FileProcessor.processFile(file)).rejects.toThrow(/Invalid JSON format/);
     });
   });
 });

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -1,26 +1,24 @@
+import { gunzipSync, strFromU8 } from "fflate";
 import { detectFieldPresence, applyNodeDefaults, applyCloneDefaults, extractGermlineFromTree } from "./fieldDefaults";
 import { NODE_TYPES, LEGACY_INTERNAL_NODE_TYPE } from "../constants/nodeTypes";
 
 /**
  * File processor for olmsted-cli consolidated format JSON files
- * Processes pre-processed consolidated format files for client-side storage
+ * Processes pre-processed consolidated format files for client-side storage.
+ * Accepts .json and .json.gz inputs; .gz payloads are decompressed in-browser
+ * via fflate before JSON parsing.
  */
 
 class FileProcessor {
   /**
-   * Process an olmsted-cli consolidated format JSON file
+   * Process an olmsted-cli consolidated format JSON file (.json or .json.gz)
    * @param {File} file - The uploaded JSON file (must be olmsted-cli consolidated format)
    * @returns {Promise<Object>} Processed data structure
    */
   static async processFile(file) {
     try {
-      const content = await this.readFile(file);
+      const content = file.name.endsWith(".gz") ? await this.readGzFileAsText(file) : await this.readFile(file);
       let data;
-
-      // Handle gzipped files
-      if (file.name.endsWith(".gz")) {
-        throw new Error("Gzipped files not yet supported in client-side processing");
-      }
 
       try {
         data = JSON.parse(content);
@@ -39,6 +37,22 @@ class FileProcessor {
     } catch (error) {
       throw new Error(`Failed to process file: ${error.message}`);
     }
+  }
+
+  /**
+   * Read a gzipped file and return its decompressed text contents.
+   * @param {File} file
+   * @returns {Promise<string>}
+   */
+  static async readGzFileAsText(file) {
+    const buffer = await this.readFileAsArrayBuffer(file);
+    let decompressed;
+    try {
+      decompressed = gunzipSync(new Uint8Array(buffer));
+    } catch (err) {
+      throw new Error(`Failed to decompress gzipped file: ${err.message}`);
+    }
+    return strFromU8(decompressed);
   }
 
   /**
@@ -209,6 +223,20 @@ class FileProcessor {
       reader.onload = (e) => resolve(e.target.result);
       reader.onerror = () => reject(new Error("File reading failed"));
       reader.readAsText(file);
+    });
+  }
+
+  /**
+   * Read file content as an ArrayBuffer (used for gzipped inputs).
+   * @param {File} file - File to read
+   * @returns {Promise<ArrayBuffer>}
+   */
+  static readFileAsArrayBuffer(file) {
+    return new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = (e) => resolve(e.target.result);
+      reader.onerror = () => reject(new Error("File reading failed"));
+      reader.readAsArrayBuffer(file);
     });
   }
 

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -17,9 +17,18 @@ class FileProcessor {
    */
   static async processFile(file) {
     try {
-      const content = file.name.endsWith(".gz") ? await this.readGzFileAsText(file) : await this.readFile(file);
-      let data;
+      let content;
+      let dataSize;
+      if (file.name.endsWith(".gz")) {
+        const { text, byteLength } = await this.readGzFile(file);
+        content = text;
+        dataSize = byteLength;
+      } else {
+        content = await this.readFile(file);
+        dataSize = file.size;
+      }
 
+      let data;
       try {
         data = JSON.parse(content);
       } catch {
@@ -33,18 +42,22 @@ class FileProcessor {
         );
       }
 
-      return this.processConsolidatedFormat(data, file.name);
+      // dataSize reflects the decompressed payload — what's actually loaded
+      // into memory and IndexedDB — not the on-disk compressed size.
+      return { ...this.processConsolidatedFormat(data, file.name), dataSize };
     } catch (error) {
       throw new Error(`Failed to process file: ${error.message}`);
     }
   }
 
   /**
-   * Read a gzipped file and return its decompressed text contents.
+   * Read a gzipped file and return both its decompressed text contents and
+   * the decompressed byte count (so callers can report the real payload size
+   * rather than the compressed on-disk size).
    * @param {File} file
-   * @returns {Promise<string>}
+   * @returns {Promise<{ text: string, byteLength: number }>}
    */
-  static async readGzFileAsText(file) {
+  static async readGzFile(file) {
     const buffer = await this.readFileAsArrayBuffer(file);
     let decompressed;
     try {
@@ -52,7 +65,7 @@ class FileProcessor {
     } catch (err) {
       throw new Error(`Failed to decompress gzipped file: ${err.message}`);
     }
-    return strFromU8(decompressed);
+    return { text: strFromU8(decompressed), byteLength: decompressed.length };
   }
 
   /**

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -16,38 +16,26 @@ class FileProcessor {
    * @returns {Promise<Object>} Processed data structure
    */
   static async processFile(file) {
+    // dataSize reflects the decompressed payload — what's actually loaded
+    // into memory and IndexedDB — not the on-disk compressed size.
+    const { content, dataSize } = file.name.toLowerCase().endsWith(".gz")
+      ? await this.readGzFile(file)
+      : { content: await this.readFile(file), dataSize: file.size };
+
+    let data;
     try {
-      let content;
-      let dataSize;
-      if (file.name.endsWith(".gz")) {
-        const { text, byteLength } = await this.readGzFile(file);
-        content = text;
-        dataSize = byteLength;
-      } else {
-        content = await this.readFile(file);
-        dataSize = file.size;
-      }
-
-      let data;
-      try {
-        data = JSON.parse(content);
-      } catch {
-        throw new Error("Invalid JSON format");
-      }
-
-      // Validate this is consolidated format
-      if (!this.isConsolidatedFormat(data)) {
-        throw new Error(
-          "File is not in olmsted-cli consolidated format. Please process your data with olmsted-cli first."
-        );
-      }
-
-      // dataSize reflects the decompressed payload — what's actually loaded
-      // into memory and IndexedDB — not the on-disk compressed size.
-      return { ...this.processConsolidatedFormat(data, file.name), dataSize };
-    } catch (error) {
-      throw new Error(`Failed to process file: ${error.message}`);
+      data = JSON.parse(content);
+    } catch {
+      throw new Error("Invalid JSON format");
     }
+
+    if (!this.isConsolidatedFormat(data)) {
+      throw new Error(
+        "File is not in olmsted-cli consolidated format. Please process your data with olmsted-cli first."
+      );
+    }
+
+    return { ...this.processConsolidatedFormat(data, file.name), dataSize };
   }
 
   /**
@@ -55,7 +43,7 @@ class FileProcessor {
    * the decompressed byte count (so callers can report the real payload size
    * rather than the compressed on-disk size).
    * @param {File} file
-   * @returns {Promise<{ text: string, byteLength: number }>}
+   * @returns {Promise<{ content: string, dataSize: number }>}
    */
   static async readGzFile(file) {
     const buffer = await this.readFileAsArrayBuffer(file);
@@ -65,7 +53,7 @@ class FileProcessor {
     } catch (err) {
       throw new Error(`Failed to decompress gzipped file: ${err.message}`);
     }
-    return { text: strFromU8(decompressed), byteLength: decompressed.length };
+    return { content: strFromU8(decompressed), dataSize: decompressed.length };
   }
 
   /**


### PR DESCRIPTION
## Summary

The Dropzone advertised `.gz` support, but both client-side processing paths threw `"not yet supported"` errors. This restores actual decompression.

- Add **fflate** (~10KB, zero deps). Use `gunzipSync` + `strFromU8` for the decompress + UTF-8 decode pipeline.
- `FileProcessor.processFile` detects `.gz` by extension, reads as ArrayBuffer (new `readFileAsArrayBuffer` helper), decompresses, then runs the existing `JSON.parse` + `isConsolidatedFormat` path.
- Decompression failures surface as `"Failed to decompress gzipped file: <reason>"`. Non-JSON-after-decompress falls into the existing `"Invalid JSON format"` branch.
- `fileUpload.js` drops the pre-check error-throw and treats `.json.gz` as consolidated. The hidden `<input>`'s `accept` and the visible "Supported formats" hint both list `.json.gz`.

## Out of scope

- `.zip`, `.tar`, `.tar.gz`, `.tgz` — never supported and out of scope per the issue.
- IndexedDB-side compression — the data is still stored as decoded JS objects via Dexie. `.gz` upload only saves the user's upload bandwidth and on-disk file size on their machine.
- Restoring an example `.json.gz` dataset file — the example data dir is gitignored.

## Test plan

- [x] `npm test` — 594 tests across 29 suites, all passing (3 new for the gz path: round-trip success, malformed gz bytes, non-JSON-after-decompress)
- [x] `npx prettier --check` and `npx eslint` on touched files — clean (pre-existing console-log warnings on untouched lines)
- [x] Manual QA: gzip a consolidated JSON dataset (`gzip dataset.json`), drop the resulting `.json.gz` into the Dropzone, confirm it loads
- [x] Manual QA: drop a corrupt `.gz` file, confirm a clear error message is shown
- [x] Manual QA: confirm uncompressed `.json` uploads still work unchanged

Closes #271.

🤖 Generated with [Claude Code](https://claude.com/claude-code)