### PR TITLE
Guard against duplicate uploads + namespace idents to fix UI cross-talk

### DIFF
--- a/src/components/splash/duplicateUploadModals.js
+++ b/src/components/splash/duplicateUploadModals.js
@@ -16,11 +16,12 @@ const overlayStyle = {
 
 const dialogStyle = {
   backgroundColor: "#fff",
-  borderRadius: "8px",
-  width: "min(540px, 92%)",
+  borderRadius: 8,
+  width: "min(520px, 92%)",
   display: "flex",
   flexDirection: "column",
-  boxShadow: "0 4px 20px rgba(0, 0, 0, 0.3)"
+  boxShadow: "0 10px 30px rgba(0, 0, 0, 0.25)",
+  fontFamily: "inherit"
 };
 
 const headerStyle = {
@@ -28,16 +29,17 @@ const headerStyle = {
   alignItems: "center",
   gap: 10,
   padding: "16px 20px",
-  borderBottom: "1px solid #dee2e6",
-  backgroundColor: "#fff8e1",
-  borderRadius: "8px 8px 0 0",
-  fontWeight: 600
+  borderBottom: "1px solid #e5e5e5",
+  fontSize: 16,
+  fontWeight: 600,
+  color: "#1f2937"
 };
 
 const bodyStyle = {
-  padding: "20px",
+  padding: "18px 20px",
   fontSize: 14,
-  lineHeight: 1.5
+  lineHeight: 1.55,
+  color: "#374151"
 };
 
 const footerStyle = {
@@ -45,57 +47,80 @@ const footerStyle = {
   justifyContent: "flex-end",
   gap: 8,
   padding: "12px 20px",
-  borderTop: "1px solid #dee2e6"
-};
-
-const buttonStyle = {
-  padding: "8px 16px",
-  borderRadius: 4,
-  border: "1px solid #ccc",
-  cursor: "pointer",
-  fontSize: 14,
-  background: "#fff"
-};
-
-const primaryButtonStyle = {
-  ...buttonStyle,
-  background: "#05337f",
-  borderColor: "#05337f",
-  color: "#fff"
+  borderTop: "1px solid #e5e5e5",
+  background: "#fafafa",
+  borderRadius: "0 0 8px 8px"
 };
 
 const inputStyle = {
   width: "100%",
   padding: "8px 10px",
   fontSize: 14,
-  border: "1px solid #ccc",
+  border: "1px solid #cbd5e1",
   borderRadius: 4,
-  marginTop: 8,
-  boxSizing: "border-box"
+  marginTop: 6,
+  boxSizing: "border-box",
+  fontFamily: "inherit"
+};
+
+// Button color tokens. "primary" = the safe action; "warning" = the risky
+// path (proceed with a duplicate). "neutral" = generic secondary.
+const BUTTON_VARIANTS = {
+  primary: {
+    base: { background: "#05337f", borderColor: "#05337f", color: "#fff" },
+    hover: { background: "#042a6b", borderColor: "#042a6b", color: "#fff" }
+  },
+  warning: {
+    base: { background: "#fff", borderColor: "#b78103", color: "#b78103" },
+    hover: { background: "#fff8e1", borderColor: "#8a6203", color: "#8a6203" }
+  },
+  neutral: {
+    base: { background: "#fff", borderColor: "#cbd5e1", color: "#374151" },
+    hover: { background: "#f3f4f6", borderColor: "#9ca3af", color: "#1f2937" }
+  }
 };
 
 /**
- * Modal shown when an uploaded dataset's `original_dataset_id` matches one
+ * Button with a built-in hover state. Variant controls the color tokens.
+ */
+function ModalButton({ variant = "neutral", onClick, children }) {
+  const [hovered, setHovered] = useState(false);
+  const tokens = BUTTON_VARIANTS[variant] || BUTTON_VARIANTS.neutral;
+  const colors = hovered ? tokens.hover : tokens.base;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      onMouseEnter={() => setHovered(true)}
+      onMouseLeave={() => setHovered(false)}
+      style={{
+        padding: "8px 16px",
+        borderRadius: 4,
+        border: "1px solid",
+        cursor: "pointer",
+        fontSize: 14,
+        fontWeight: 500,
+        transition: "background 0.15s ease, color 0.15s ease, border-color 0.15s ease",
+        ...colors
+      }}
+    >
+      {children}
+    </button>
+  );
+}
+
+/**
+ * Modal shown when an uploaded dataset's source identity matches one
  * already loaded in the local database. The user can either cancel the
- * upload or proceed (in which case the caller will rename the source ID
- * to a non-colliding suffix).
+ * upload or save it as a separate dataset (the caller renames the source
+ * id behind the scenes).
  *
  * @param {Object} props
- * @param {string} props.uploadName - name of the dataset being uploaded
  * @param {string} props.existingName - name of the already-loaded dataset
- * @param {string} props.originalDatasetId - the colliding source id
- * @param {string} props.proposedNewId - the auto-renamed id ("foo-1", etc.)
  * @param {() => void} props.onCancel
  * @param {() => void} props.onContinue
  */
-export function DuplicateIdWarningModal({
-  uploadName,
-  existingName,
-  originalDatasetId,
-  proposedNewId,
-  onCancel,
-  onContinue
-}) {
+export function DuplicateIdWarningModal({ existingName, onCancel, onContinue }) {
   return (
     <div style={overlayStyle} role="dialog" aria-modal="true" aria-labelledby="dup-id-title">
       <div style={dialogStyle}>
@@ -104,28 +129,27 @@ export function DuplicateIdWarningModal({
         </div>
         <div style={bodyStyle}>
           <p style={{ marginTop: 0 }}>
-            A dataset with source id <code>{originalDatasetId}</code> is already loaded
+            This upload appears to match a dataset already loaded in your browser
             {existingName ? (
               <>
-                {" "}
-                as <strong>{existingName}</strong>
+                : <strong>{existingName}</strong>
               </>
-            ) : null}
-            .
+            ) : (
+              "."
+            )}
           </p>
-          <p>
-            If this is the same dataset re-uploaded, you probably want to cancel. Otherwise the upload of{" "}
-            <strong>{uploadName}</strong> will be saved with a renamed source id <code>{proposedNewId}</code> so it
-            doesn&apos;t conflict.
+          <p style={{ marginBottom: 0 }}>
+            If this is the same dataset you already uploaded, cancel. Otherwise it can be saved as a separate entry
+            alongside the existing one.
           </p>
         </div>
         <div style={footerStyle}>
-          <button type="button" style={buttonStyle} onClick={onCancel}>
+          <ModalButton variant="warning" onClick={onContinue}>
+            Save as separate dataset
+          </ModalButton>
+          <ModalButton variant="primary" onClick={onCancel}>
             Cancel upload
-          </button>
-          <button type="button" style={primaryButtonStyle} onClick={onContinue}>
-            Continue with renamed id
-          </button>
+          </ModalButton>
         </div>
       </div>
     </div>
@@ -147,6 +171,7 @@ export function DuplicateNameModal({ originalName, suggestedName, onAccept, onCa
   const [value, setValue] = useState(suggestedName);
   const trimmed = value.trim();
   const willKeepDuplicate = trimmed === originalName;
+  const finalLabel = trimmed.length > 0 ? trimmed : originalName;
 
   return (
     <div style={overlayStyle} role="dialog" aria-modal="true" aria-labelledby="dup-name-title">
@@ -157,9 +182,9 @@ export function DuplicateNameModal({ originalName, suggestedName, onAccept, onCa
         <div style={bodyStyle}>
           <p style={{ marginTop: 0 }}>
             A dataset called <strong>{originalName}</strong> is already loaded. Edit the name below to disambiguate, or
-            keep the duplicate if you really want to.
+            keep the duplicate name if you really want to.
           </p>
-          <label htmlFor="dup-name-input" style={{ fontSize: 13, color: "#555" }}>
+          <label htmlFor="dup-name-input" style={{ fontSize: 13, color: "#6b7280" }}>
             Dataset name
           </label>
           <input
@@ -172,23 +197,19 @@ export function DuplicateNameModal({ originalName, suggestedName, onAccept, onCa
             autoFocus
           />
           {willKeepDuplicate && (
-            <p style={{ color: "#b78103", fontSize: 13, marginTop: 8 }}>
-              You&apos;ll have two datasets with the same name. They&apos;ll be distinguishable only by their source id
-              and upload time.
+            <p style={{ color: "#b78103", fontSize: 13, marginTop: 8, marginBottom: 0 }}>
+              You&apos;ll have two datasets with the same name. They&apos;ll only be distinguishable by their upload
+              time.
             </p>
           )}
         </div>
         <div style={footerStyle}>
-          <button type="button" style={buttonStyle} onClick={onCancel}>
+          <ModalButton variant="neutral" onClick={onCancel}>
             Cancel upload
-          </button>
-          <button
-            type="button"
-            style={primaryButtonStyle}
-            onClick={() => onAccept(trimmed.length > 0 ? trimmed : originalName)}
-          >
+          </ModalButton>
+          <ModalButton variant={willKeepDuplicate ? "warning" : "primary"} onClick={() => onAccept(finalLabel)}>
             {willKeepDuplicate ? "Keep duplicate name" : "Use this name"}
-          </button>
+          </ModalButton>
         </div>
       </div>
     </div>

--- a/src/components/splash/duplicateUploadModals.js
+++ b/src/components/splash/duplicateUploadModals.js
@@ -1,0 +1,196 @@
+import React, { useState } from "react";
+import { FiAlertTriangle } from "react-icons/fi";
+
+const overlayStyle = {
+  position: "fixed",
+  top: 0,
+  left: 0,
+  right: 0,
+  bottom: 0,
+  backgroundColor: "rgba(0, 0, 0, 0.5)",
+  display: "flex",
+  alignItems: "center",
+  justifyContent: "center",
+  zIndex: 10000
+};
+
+const dialogStyle = {
+  backgroundColor: "#fff",
+  borderRadius: "8px",
+  width: "min(540px, 92%)",
+  display: "flex",
+  flexDirection: "column",
+  boxShadow: "0 4px 20px rgba(0, 0, 0, 0.3)"
+};
+
+const headerStyle = {
+  display: "flex",
+  alignItems: "center",
+  gap: 10,
+  padding: "16px 20px",
+  borderBottom: "1px solid #dee2e6",
+  backgroundColor: "#fff8e1",
+  borderRadius: "8px 8px 0 0",
+  fontWeight: 600
+};
+
+const bodyStyle = {
+  padding: "20px",
+  fontSize: 14,
+  lineHeight: 1.5
+};
+
+const footerStyle = {
+  display: "flex",
+  justifyContent: "flex-end",
+  gap: 8,
+  padding: "12px 20px",
+  borderTop: "1px solid #dee2e6"
+};
+
+const buttonStyle = {
+  padding: "8px 16px",
+  borderRadius: 4,
+  border: "1px solid #ccc",
+  cursor: "pointer",
+  fontSize: 14,
+  background: "#fff"
+};
+
+const primaryButtonStyle = {
+  ...buttonStyle,
+  background: "#05337f",
+  borderColor: "#05337f",
+  color: "#fff"
+};
+
+const inputStyle = {
+  width: "100%",
+  padding: "8px 10px",
+  fontSize: 14,
+  border: "1px solid #ccc",
+  borderRadius: 4,
+  marginTop: 8,
+  boxSizing: "border-box"
+};
+
+/**
+ * Modal shown when an uploaded dataset's `original_dataset_id` matches one
+ * already loaded in the local database. The user can either cancel the
+ * upload or proceed (in which case the caller will rename the source ID
+ * to a non-colliding suffix).
+ *
+ * @param {Object} props
+ * @param {string} props.uploadName - name of the dataset being uploaded
+ * @param {string} props.existingName - name of the already-loaded dataset
+ * @param {string} props.originalDatasetId - the colliding source id
+ * @param {string} props.proposedNewId - the auto-renamed id ("foo-1", etc.)
+ * @param {() => void} props.onCancel
+ * @param {() => void} props.onContinue
+ */
+export function DuplicateIdWarningModal({
+  uploadName,
+  existingName,
+  originalDatasetId,
+  proposedNewId,
+  onCancel,
+  onContinue
+}) {
+  return (
+    <div style={overlayStyle} role="dialog" aria-modal="true" aria-labelledby="dup-id-title">
+      <div style={dialogStyle}>
+        <div style={headerStyle} id="dup-id-title">
+          <FiAlertTriangle color="#b78103" /> Possible duplicate dataset
+        </div>
+        <div style={bodyStyle}>
+          <p style={{ marginTop: 0 }}>
+            A dataset with source id <code>{originalDatasetId}</code> is already loaded
+            {existingName ? (
+              <>
+                {" "}
+                as <strong>{existingName}</strong>
+              </>
+            ) : null}
+            .
+          </p>
+          <p>
+            If this is the same dataset re-uploaded, you probably want to cancel. Otherwise the upload of{" "}
+            <strong>{uploadName}</strong> will be saved with a renamed source id <code>{proposedNewId}</code> so it
+            doesn&apos;t conflict.
+          </p>
+        </div>
+        <div style={footerStyle}>
+          <button type="button" style={buttonStyle} onClick={onCancel}>
+            Cancel upload
+          </button>
+          <button type="button" style={primaryButtonStyle} onClick={onContinue}>
+            Continue with renamed id
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Modal shown when the uploaded dataset's display name matches one already
+ * loaded. The user can edit the name (pre-filled with the next free
+ * `name (n)`), accept it as-is, or keep the original duplicate name.
+ *
+ * @param {Object} props
+ * @param {string} props.originalName - name as it would appear without the change
+ * @param {string} props.suggestedName - "{name} (1)" or next-available
+ * @param {(finalName: string) => void} props.onAccept
+ * @param {() => void} props.onCancel
+ */
+export function DuplicateNameModal({ originalName, suggestedName, onAccept, onCancel }) {
+  const [value, setValue] = useState(suggestedName);
+  const trimmed = value.trim();
+  const willKeepDuplicate = trimmed === originalName;
+
+  return (
+    <div style={overlayStyle} role="dialog" aria-modal="true" aria-labelledby="dup-name-title">
+      <div style={dialogStyle}>
+        <div style={headerStyle} id="dup-name-title">
+          <FiAlertTriangle color="#b78103" /> Dataset name already in use
+        </div>
+        <div style={bodyStyle}>
+          <p style={{ marginTop: 0 }}>
+            A dataset called <strong>{originalName}</strong> is already loaded. Edit the name below to disambiguate, or
+            keep the duplicate if you really want to.
+          </p>
+          <label htmlFor="dup-name-input" style={{ fontSize: 13, color: "#555" }}>
+            Dataset name
+          </label>
+          <input
+            id="dup-name-input"
+            type="text"
+            style={inputStyle}
+            value={value}
+            onChange={(e) => setValue(e.target.value)}
+            // eslint-disable-next-line jsx-a11y/no-autofocus
+            autoFocus
+          />
+          {willKeepDuplicate && (
+            <p style={{ color: "#b78103", fontSize: 13, marginTop: 8 }}>
+              You&apos;ll have two datasets with the same name. They&apos;ll be distinguishable only by their source id
+              and upload time.
+            </p>
+          )}
+        </div>
+        <div style={footerStyle}>
+          <button type="button" style={buttonStyle} onClick={onCancel}>
+            Cancel upload
+          </button>
+          <button
+            type="button"
+            style={primaryButtonStyle}
+            onClick={() => onAccept(trimmed.length > 0 ? trimmed : originalName)}
+          >
+            {willKeepDuplicate ? "Keep duplicate name" : "Use this name"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/splash/fileUpload.js
+++ b/src/components/splash/fileUpload.js
@@ -5,9 +5,11 @@ import { CenterContent } from "./centerContent";
 import FileProcessor from "../../utils/fileProcessor";
 import SplitFileProcessor from "../../utils/splitFileProcessor";
 import clientDataStore from "../../utils/clientDataStore";
+import olmstedDB from "../../utils/olmstedDB";
 import { getMissingFieldSummary } from "../../utils/fieldDefaults";
 import { getClientDatasets } from "../../actions/clientDataLoader";
 import { SimpleInProgress } from "../util/loading";
+import { DuplicateIdWarningModal, DuplicateNameModal } from "./duplicateUploadModals";
 
 class FileUpload extends React.Component {
   constructor(props) {
@@ -20,7 +22,12 @@ class FileUpload extends React.Component {
       loadingStage: "",
       loadingProgress: 0,
       dropzoneHovered: false,
-      removeHoveredId: null
+      removeHoveredId: null,
+      // Duplicate-upload guard state. When set, the corresponding modal is
+      // rendered and we hold a `resolve` function that the modal callbacks
+      // invoke to unblock the in-flight upload.
+      pendingIdConflict: null,
+      pendingNameConflict: null
     };
 
     this.processFile = this.processFile.bind(this);
@@ -52,6 +59,68 @@ class FileUpload extends React.Component {
       loadingStage: stage,
       loadingProgress: Math.min(100, Math.max(0, progress))
     });
+  }
+
+  /**
+   * Promise-returning helper that opens the duplicate-id modal and resolves
+   * with `true` if the user wants to continue with a renamed source id,
+   * `false` if they cancel.
+   */
+  presentIdConflictModal(payload) {
+    return new Promise((resolve) => {
+      this.setState({ pendingIdConflict: { ...payload, resolve } });
+    });
+  }
+
+  /**
+   * Promise-returning helper that opens the duplicate-name modal and
+   * resolves with the chosen final name (a string, possibly equal to
+   * `originalName` if the user keeps the duplicate) or `null` if they
+   * cancel the upload.
+   */
+  presentNameConflictModal(payload) {
+    return new Promise((resolve) => {
+      this.setState({ pendingNameConflict: { ...payload, resolve } });
+    });
+  }
+
+  /**
+   * Run both duplicate-upload guards against the processed dataset.
+   * Mutates `result.datasets[0]` (and clones[*].dataset_id refs) when the
+   * user opts to continue with renamed values. Returns true if the upload
+   * should proceed, false if the user cancelled.
+   */
+  async resolveDuplicateConflicts(result) {
+    const dataset = result.datasets && result.datasets[0];
+    if (!dataset) return true;
+
+    // Check 1: original_dataset_id collision.
+    const idCollision = await olmstedDB.findDatasetByOriginalId(dataset.original_dataset_id);
+    if (idCollision) {
+      const proposedNewId = await olmstedDB.makeUniqueOriginalDatasetId(dataset.original_dataset_id);
+      const continueAnyway = await this.presentIdConflictModal({
+        uploadName: dataset.name,
+        existingName: idCollision.name,
+        originalDatasetId: dataset.original_dataset_id,
+        proposedNewId
+      });
+      if (!continueAnyway) return false;
+      dataset.original_dataset_id = proposedNewId;
+    }
+
+    // Check 2: dataset name collision.
+    const nameCollision = await olmstedDB.findDatasetByName(dataset.name);
+    if (nameCollision) {
+      const suggestedName = await olmstedDB.makeUniqueDatasetName(dataset.name);
+      const finalName = await this.presentNameConflictModal({
+        originalName: dataset.name,
+        suggestedName
+      });
+      if (finalName === null) return false;
+      dataset.name = finalName;
+    }
+
+    return true;
   }
 
   async processFile(file) {
@@ -89,6 +158,15 @@ class FileUpload extends React.Component {
       // Add file size to the first dataset
       if (result.datasets && result.datasets.length > 0) {
         result.datasets[0].file_size = file.size;
+      }
+
+      // Guard against duplicate uploads (same source id and/or same display
+      // name as an already-loaded dataset). Modals may pause the upload here.
+      this.updateLoadingStatus("Checking for duplicate datasets...", 60);
+      const proceed = await this.resolveDuplicateConflicts(result);
+      if (!proceed) {
+        this.setState({ isProcessing: false, loadingStage: "", loadingProgress: 0 });
+        return;
       }
 
       // Store processed data in browser (IndexedDB)
@@ -200,6 +278,14 @@ class FileUpload extends React.Component {
             consolidatedResult.datasets[0].file_size = totalSize;
           }
 
+          // Guard against duplicate uploads (same source id and/or same name).
+          this.updateLoadingStatus("Checking for duplicate datasets...", 65);
+          const proceedSplit = await this.resolveDuplicateConflicts(consolidatedResult);
+          if (!proceedSplit) {
+            this.setState({ isProcessing: false, loadingStage: "", loadingProgress: 0 });
+            return;
+          }
+
           // Store processed data
           this.updateLoadingStatus("Storing data in browser database...", 75);
           await clientDataStore.storeProcessedData(consolidatedResult);
@@ -279,12 +365,55 @@ class FileUpload extends React.Component {
     console.log("Removed dataset from client storage:", datasetId);
   }
 
+  resolvePendingIdConflict = (continueAnyway) => {
+    const { pendingIdConflict } = this.state;
+    if (pendingIdConflict) {
+      pendingIdConflict.resolve(continueAnyway);
+    }
+    this.setState({ pendingIdConflict: null });
+  };
+
+  resolvePendingNameConflict = (finalName) => {
+    const { pendingNameConflict } = this.state;
+    if (pendingNameConflict) {
+      pendingNameConflict.resolve(finalName);
+    }
+    this.setState({ pendingNameConflict: null });
+  };
+
   render() {
-    const { uploadedFiles, isProcessing, error, _loadingStage, _loadingProgress, loadingProgress, loadingStage } =
-      this.state;
+    const {
+      uploadedFiles,
+      isProcessing,
+      error,
+      _loadingStage,
+      _loadingProgress,
+      loadingProgress,
+      loadingStage,
+      pendingIdConflict,
+      pendingNameConflict
+    } = this.state;
 
     return (
       <CenterContent>
+        {pendingIdConflict && (
+          <DuplicateIdWarningModal
+            uploadName={pendingIdConflict.uploadName}
+            existingName={pendingIdConflict.existingName}
+            originalDatasetId={pendingIdConflict.originalDatasetId}
+            proposedNewId={pendingIdConflict.proposedNewId}
+            onCancel={() => this.resolvePendingIdConflict(false)}
+            onContinue={() => this.resolvePendingIdConflict(true)}
+          />
+        )}
+        {pendingNameConflict && (
+          <DuplicateNameModal
+            originalName={pendingNameConflict.originalName}
+            suggestedName={pendingNameConflict.suggestedName}
+            onCancel={() => this.resolvePendingNameConflict(null)}
+            onAccept={(name) => this.resolvePendingNameConflict(name)}
+          />
+        )}
         <div style={{ marginTop: 40, marginBottom: 40 }}>
           {/* Hidden file input for programmatic access */}
           <input

--- a/src/components/splash/fileUpload.js
+++ b/src/components/splash/fileUpload.js
@@ -97,15 +97,9 @@ class FileUpload extends React.Component {
     // Check 1: original_dataset_id collision.
     const idCollision = await olmstedDB.findDatasetByOriginalId(dataset.original_dataset_id);
     if (idCollision) {
-      const proposedNewId = await olmstedDB.makeUniqueOriginalDatasetId(dataset.original_dataset_id);
-      const continueAnyway = await this.presentIdConflictModal({
-        uploadName: dataset.name,
-        existingName: idCollision.name,
-        originalDatasetId: dataset.original_dataset_id,
-        proposedNewId
-      });
+      const continueAnyway = await this.presentIdConflictModal({ existingName: idCollision.name });
       if (!continueAnyway) return false;
-      dataset.original_dataset_id = proposedNewId;
+      dataset.original_dataset_id = await olmstedDB.makeUniqueOriginalDatasetId(dataset.original_dataset_id);
     }
 
     // Check 2: dataset name collision.
@@ -398,10 +392,7 @@ class FileUpload extends React.Component {
       <CenterContent>
         {pendingIdConflict && (
           <DuplicateIdWarningModal
-            uploadName={pendingIdConflict.uploadName}
             existingName={pendingIdConflict.existingName}
-            originalDatasetId={pendingIdConflict.originalDatasetId}
-            proposedNewId={pendingIdConflict.proposedNewId}
             onCancel={() => this.resolvePendingIdConflict(false)}
             onContinue={() => this.resolvePendingIdConflict(true)}
           />

--- a/src/components/splash/fileUpload.js
+++ b/src/components/splash/fileUpload.js
@@ -61,6 +61,15 @@ class FileUpload extends React.Component {
     });
   }
 
+  componentWillUnmount() {
+    // If a modal is still pending when the component unmounts, resolve its
+    // promise as a cancel so the awaiting upload can settle without later
+    // calling setState on an unmounted component.
+    const { pendingIdConflict, pendingNameConflict } = this.state;
+    if (pendingIdConflict) pendingIdConflict.resolve(false);
+    if (pendingNameConflict) pendingNameConflict.resolve(null);
+  }
+
   /**
    * Promise-returning helper that opens the duplicate-id modal and resolves
    * with `true` if the user wants to continue with a renamed source id,

--- a/src/components/tables/RowInfoModal.js
+++ b/src/components/tables/RowInfoModal.js
@@ -347,7 +347,8 @@ export function InfoButtonCell({ datum }) {
   const getTitle = () => {
     if (datum.name) return datum.name;
     if (datum.dataset_id) return `Dataset: ${datum.dataset_id}`;
-    if (datum.ident) return `Family: ${datum.ident}`;
+    // Prefer the source ident over the namespaced storage ident for display.
+    if (datum.original_ident || datum.ident) return `Family: ${datum.original_ident || datum.ident}`;
     if (datum.id) return `ID: ${datum.id}`;
     return "Row Details";
   };

--- a/src/components/util/incomplete.js
+++ b/src/components/util/incomplete.js
@@ -9,7 +9,8 @@ import React from "react";
  * @param {string[]} [props.reasons] - Specific reasons for incompleteness
  */
 function IncompleteDataWarning({ datum, data_type, reasons }) {
-  const id = datum.clone_id || datum.id || datum.ident || datum.tree_id;
+  // Prefer the source ident over the namespaced storage ident for display.
+  const id = datum.clone_id || datum.id || datum.original_ident || datum.ident || datum.tree_id;
   return (
     <div
       style={{

--- a/src/constants/nodeTypes.js
+++ b/src/constants/nodeTypes.js
@@ -7,9 +7,11 @@
  * (including original roots demoted when assembling a forest under a
  * synthetic root).
  *
- * Historical note: an older olmsted-cli emitted "internal" instead of
- * "node". One vestigial Vega filter accepted both, but nothing in the
- * current pipeline emits "internal" — the value has been removed.
+ * Compatibility note: some olmsted-cli outputs (e.g. the pcp-byhand
+ * golden data) tag intermediate nodes with the older value "internal".
+ * fileProcessor.processConsolidatedFormat coalesces "internal" → "node"
+ * on ingest so the rest of the codebase only has to deal with the
+ * canonical NODE_TYPES values.
  */
 
 export const NODE_TYPES = {

--- a/src/constants/nodeTypes.js
+++ b/src/constants/nodeTypes.js
@@ -20,3 +20,10 @@ export const NODE_TYPES = {
   NAIVE: "naive",
   NODE: "node"
 };
+
+/**
+ * Legacy synonym some olmsted-cli outputs still emit for intermediate
+ * nodes. Coalesced to NODE_TYPES.NODE on ingest by
+ * fileProcessor.processConsolidatedFormat.
+ */
+export const LEGACY_INTERNAL_NODE_TYPE = "internal";

--- a/src/utils/__tests__/fileProcessor.test.js
+++ b/src/utils/__tests__/fileProcessor.test.js
@@ -112,6 +112,31 @@ describe("FileProcessor", () => {
       const emptyData = { ...validData, datasets: [] };
       expect(() => FileProcessor.processConsolidatedFormat(emptyData, "test.json")).toThrow("missing datasets");
     });
+
+    it("coalesces legacy node type 'internal' onto canonical 'node'", () => {
+      // Some olmsted-cli outputs (e.g. pcp-byhand-olmsted-golden.json) tag
+      // intermediate nodes with "internal" instead of "node".
+      const dataWithInternal = {
+        ...validData,
+        trees: [
+          {
+            ident: "tree-1",
+            clone_id: "c1",
+            nodes: [
+              { sequence_id: "naive", type: "root" },
+              { sequence_id: "intermediate", type: "internal" },
+              { sequence_id: "leaf-1", type: "leaf" }
+            ]
+          }
+        ]
+      };
+      const result = FileProcessor.processConsolidatedFormat(dataWithInternal, "test.json");
+      const nodes = result.trees[0].nodes;
+      expect(nodes["intermediate"].type).toBe("node");
+      // Other types pass through unchanged.
+      expect(nodes["naive"].type).toBe("root");
+      expect(nodes["leaf-1"].type).toBe("leaf");
+    });
   });
 
   describe("generateDatasetId", () => {

--- a/src/utils/__tests__/olmstedDB.test.js
+++ b/src/utils/__tests__/olmstedDB.test.js
@@ -5,6 +5,7 @@
  */
 
 import Dexie from "dexie";
+import { firstAvailable } from "../olmstedDB";
 
 // We can't use the singleton; import the class and create fresh instances.
 // The module exports a singleton, so we re-create the class pattern here.
@@ -274,5 +275,33 @@ describe("cascade delete pattern", () => {
     expect(await db.datasets.count()).toBe(0);
     expect(await db.clones.count()).toBe(0);
     expect(await db.trees.count()).toBe(0);
+  });
+});
+
+// ── firstAvailable (pure helper) ──
+
+describe("firstAvailable", () => {
+  const dashSuffix = (base, n) => `${base}-${n}`;
+  const parenSuffix = (base, n) => `${base} (${n})`;
+
+  it("returns the bare base when it isn't taken", () => {
+    expect(firstAvailable("ds-7", [], dashSuffix)).toBe("ds-7");
+    expect(firstAvailable("My Dataset", ["Other"], parenSuffix)).toBe("My Dataset");
+  });
+
+  it("appends -1 on first collision and -2 if -1 is also taken", () => {
+    expect(firstAvailable("ds-7", ["ds-7"], dashSuffix)).toBe("ds-7-1");
+    expect(firstAvailable("ds-7", ["ds-7", "ds-7-1"], dashSuffix)).toBe("ds-7-2");
+    expect(firstAvailable("ds-7", ["ds-7", "ds-7-1", "ds-7-2"], dashSuffix)).toBe("ds-7-3");
+  });
+
+  it("uses the parenthesized format for names", () => {
+    expect(firstAvailable("My Data", ["My Data"], parenSuffix)).toBe("My Data (1)");
+    expect(firstAvailable("My Data", ["My Data", "My Data (1)"], parenSuffix)).toBe("My Data (2)");
+  });
+
+  it("does not jump over an existing intermediate (1)/(2) pair when base is free", () => {
+    // If base is unused, the function returns it even if `{base} (1)` is taken.
+    expect(firstAvailable("My Data", ["My Data (1)"], parenSuffix)).toBe("My Data");
   });
 });

--- a/src/utils/__tests__/olmstedDB.test.js
+++ b/src/utils/__tests__/olmstedDB.test.js
@@ -5,7 +5,7 @@
  */
 
 import Dexie from "dexie";
-import { firstAvailable, namespacedIdent } from "../olmstedDB";
+import olmstedDB, { firstAvailable, namespacedIdent } from "../olmstedDB";
 
 // We can't use the singleton; import the class and create fresh instances.
 // The module exports a singleton, so we re-create the class pattern here.
@@ -322,5 +322,73 @@ describe("namespacedIdent", () => {
     const original = "fam_5";
     const namespaced = namespacedIdent(datasetId, original);
     expect(namespaced.slice(`${datasetId}::`.length)).toBe(original);
+  });
+});
+
+// ── storeDataset namespacing (integration through the singleton) ──
+//
+// These tests exercise the actual storeDataset codepath, against the
+// singleton's DB (fake-indexeddb in tests). The data-corruption bug we
+// fixed was that two datasets sharing tree idents would clobber each
+// other on `bulkPut` to the trees table; the unit-helper tests above
+// don't catch that because they don't go through the storage layer.
+
+describe("storeDataset (namespacing integration)", () => {
+  beforeEach(async () => {
+    await olmstedDB.ready;
+    await olmstedDB.clearAll();
+  });
+
+  const buildDataset = (datasetId, sharedCloneIdent, sharedTreeIdent) => ({
+    datasetId,
+    datasets: [{ dataset_id: datasetId, ident: "ds-shared", name: `Dataset ${datasetId}` }],
+    clones: {
+      [datasetId]: [
+        {
+          clone_id: "fam-1",
+          ident: sharedCloneIdent,
+          dataset_id: datasetId,
+          trees: [{ ident: sharedTreeIdent, tree_id: "t-1" }]
+        }
+      ]
+    },
+    trees: [{ ident: sharedTreeIdent, tree_id: "t-1", clone_id: "fam-1", nodes: { naive: { type: "root" } } }]
+  });
+
+  it("preserves both datasets when their clone and tree idents collide", async () => {
+    await olmstedDB.storeDataset(buildDataset("upload-A", "shared-clone", "shared-tree"));
+    await olmstedDB.storeDataset(buildDataset("upload-B", "shared-clone", "shared-tree"));
+
+    expect(await olmstedDB.datasets.count()).toBe(2);
+    expect(await olmstedDB.clones.count()).toBe(2);
+    expect(await olmstedDB.trees.count()).toBe(2);
+  });
+
+  it("rewrites clone and tree idents to namespaced form on store", async () => {
+    await olmstedDB.storeDataset(buildDataset("upload-A", "shared-clone", "shared-tree"));
+    const clones = await olmstedDB.clones.toArray();
+    const trees = await olmstedDB.trees.toArray();
+    expect(clones[0].ident).toBe("upload-A::shared-clone");
+    expect(clones[0].original_ident).toBe("shared-clone");
+    expect(trees[0].ident).toBe("upload-A::shared-tree");
+    expect(trees[0].original_ident).toBe("shared-tree");
+  });
+
+  it("namespaces the trees_meta projection on each clone so the dropdown looks up the right tree", async () => {
+    await olmstedDB.storeDataset(buildDataset("upload-A", "shared-clone", "shared-tree"));
+    const clones = await olmstedDB.clones.toArray();
+    expect(clones[0].trees_meta[0].ident).toBe("upload-A::shared-tree");
+    expect(clones[0].trees_meta[0].original_ident).toBe("shared-tree");
+  });
+
+  it("auto-renames colliding dataset.ident on insert", async () => {
+    await olmstedDB.storeDataset(buildDataset("upload-A", "c1", "t1"));
+    await olmstedDB.storeDataset(buildDataset("upload-B", "c2", "t2"));
+    const datasets = await olmstedDB.datasets.toArray();
+    const idents = datasets.map((d) => d.ident).sort();
+    expect(idents).toEqual(["ds-shared", "ds-shared-1"]);
+    // original_ident is preserved on the renamed entry
+    const renamed = datasets.find((d) => d.ident === "ds-shared-1");
+    expect(renamed.original_ident).toBe("ds-shared");
   });
 });

--- a/src/utils/__tests__/olmstedDB.test.js
+++ b/src/utils/__tests__/olmstedDB.test.js
@@ -5,7 +5,7 @@
  */
 
 import Dexie from "dexie";
-import { firstAvailable } from "../olmstedDB";
+import { firstAvailable, namespacedIdent } from "../olmstedDB";
 
 // We can't use the singleton; import the class and create fresh instances.
 // The module exports a singleton, so we re-create the class pattern here.
@@ -303,5 +303,24 @@ describe("firstAvailable", () => {
   it("does not jump over an existing intermediate (1)/(2) pair when base is free", () => {
     // If base is unused, the function returns it even if `{base} (1)` is taken.
     expect(firstAvailable("My Data", ["My Data (1)"], parenSuffix)).toBe("My Data");
+  });
+});
+
+// ── namespacedIdent (pure helper) ──
+
+describe("namespacedIdent", () => {
+  it("prefixes ident with the dataset id and a :: separator", () => {
+    expect(namespacedIdent("upload-1", "fam_5")).toBe("upload-1::fam_5");
+  });
+
+  it("produces distinct outputs for the same source ident in different datasets", () => {
+    expect(namespacedIdent("upload-1", "fam_5")).not.toBe(namespacedIdent("upload-2", "fam_5"));
+  });
+
+  it("does not lose information — the original ident is recoverable", () => {
+    const datasetId = "upload-abc";
+    const original = "fam_5";
+    const namespaced = namespacedIdent(datasetId, original);
+    expect(namespaced.slice(`${datasetId}::`.length)).toBe(original);
   });
 });

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -1,4 +1,5 @@
 import { detectFieldPresence, applyNodeDefaults, applyCloneDefaults, extractGermlineFromTree } from "./fieldDefaults";
+import { NODE_TYPES } from "../constants/nodeTypes";
 
 /**
  * File processor for olmsted-cli consolidated format JSON files
@@ -127,11 +128,16 @@ class FileProcessor {
         }
       }
 
-      // Convert nodes array to object indexed by sequence_id
+      // Convert nodes array to object indexed by sequence_id.
+      // Some olmsted-cli outputs (e.g. pcp-byhand-olmsted-golden) tag
+      // intermediate nodes with type "internal"; the rest of the codebase
+      // treats "node" as canonical. Coalesce here so downstream selectors
+      // and Vega filters don't have to accept both spellings.
       const processedNodes = {};
       if (nodesList) {
         nodesList.forEach((node, nodeIndex) => {
           const nodeId = node.sequence_id || String(nodeIndex);
+          if (node.type === "internal") node.type = NODE_TYPES.NODE;
           applyNodeDefaults(node);
           processedNodes[nodeId] = node;
         });

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -1,5 +1,5 @@
 import { detectFieldPresence, applyNodeDefaults, applyCloneDefaults, extractGermlineFromTree } from "./fieldDefaults";
-import { NODE_TYPES } from "../constants/nodeTypes";
+import { NODE_TYPES, LEGACY_INTERNAL_NODE_TYPE } from "../constants/nodeTypes";
 
 /**
  * File processor for olmsted-cli consolidated format JSON files
@@ -137,7 +137,7 @@ class FileProcessor {
       if (nodesList) {
         nodesList.forEach((node, nodeIndex) => {
           const nodeId = node.sequence_id || String(nodeIndex);
-          if (node.type === "internal") node.type = NODE_TYPES.NODE;
+          if (node.type === LEGACY_INTERNAL_NODE_TYPE) node.type = NODE_TYPES.NODE;
           applyNodeDefaults(node);
           processedNodes[nodeId] = node;
         });

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -4,6 +4,24 @@
 
 import Dexie from "dexie";
 
+/**
+ * Return the lowest-numbered candidate that doesn't appear in `taken`,
+ * starting from the bare `base` and walking through `format(base, 1)`,
+ * `format(base, 2)`, .... Pure helper, no DB access.
+ *
+ * @param {string} base
+ * @param {Iterable<string>} taken
+ * @param {(base: string, n: number) => string} format
+ * @returns {string}
+ */
+export const firstAvailable = (base, taken, format) => {
+  const set = new Set(taken);
+  if (!set.has(base)) return base;
+  let n = 1;
+  while (set.has(format(base, n))) n += 1;
+  return format(base, n);
+};
+
 class OlmstedDB extends Dexie {
   constructor() {
     super("OlmstedClientStorage");
@@ -125,6 +143,68 @@ class OlmstedDB extends Dexie {
       console.error("OlmstedDB: Failed to get datasets:", error);
       return [];
     }
+  }
+
+  /**
+   * Find an already-loaded dataset whose original_dataset_id matches the
+   * given value. Storage `dataset_id`s are always unique (Date.now-based)
+   * and never collide; we check `original_dataset_id` to detect "the same
+   * source dataset is already loaded."
+   *
+   * @param {string} originalDatasetId
+   * @returns {Promise<Object|null>} the existing dataset or null
+   */
+  async findDatasetByOriginalId(originalDatasetId) {
+    if (!originalDatasetId) return null;
+    try {
+      const all = await this.datasets.toArray();
+      return all.find((d) => d.original_dataset_id === originalDatasetId) || null;
+    } catch (error) {
+      console.error("OlmstedDB: Failed to look up dataset by original_dataset_id:", error);
+      return null;
+    }
+  }
+
+  /**
+   * Find an already-loaded dataset whose user-facing `name` matches.
+   *
+   * @param {string} name
+   * @returns {Promise<Object|null>}
+   */
+  async findDatasetByName(name) {
+    if (!name) return null;
+    try {
+      return (await this.datasets.where("name").equals(name).first()) || null;
+    } catch (error) {
+      console.error("OlmstedDB: Failed to look up dataset by name:", error);
+      return null;
+    }
+  }
+
+  /**
+   * See module-level firstAvailable for the pure implementation.
+   *
+   * @param {string} candidate
+   * @returns {Promise<string>}
+   */
+  async makeUniqueOriginalDatasetId(candidate) {
+    const all = await this.datasets.toArray();
+    const taken = all.map((d) => d.original_dataset_id).filter(Boolean);
+    return firstAvailable(candidate, taken, (base, n) => `${base}-${n}`);
+  }
+
+  /**
+   * See module-level firstAvailable for the pure implementation. The user
+   * can override the returned suggestion with anything (including a
+   * duplicate) — this just produces the default shown in the rename modal.
+   *
+   * @param {string} candidate
+   * @returns {Promise<string>}
+   */
+  async makeUniqueDatasetName(candidate) {
+    const all = await this.datasets.toArray();
+    const taken = all.map((d) => d.name).filter(Boolean);
+    return firstAvailable(candidate, taken, (base, n) => `${base} (${n})`);
   }
 
   /**

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -85,9 +85,27 @@ class OlmstedDB extends Dexie {
 
     try {
       await this.transaction("rw", this.datasets, this.clones, this.trees, async () => {
-        // Store dataset metadata using bulk operation
+        // Store dataset metadata using bulk operation. Dataset records carry
+        // an `ident` field from the source file (separate from `dataset_id`,
+        // which is the unique storage PK). Source idents can collide across
+        // re-imports and sibling datasets — and ResizableTable derives
+        // rowId from `datum.ident` before falling back to `datum.dataset_id`,
+        // so collisions show up as hover/select cross-talk in the dataset
+        // tables. Auto-rename on collision to keep ident unique; preserve
+        // the original as `original_ident`. (The duplicate-upload modal
+        // already covers the user-facing "are you sure?" via
+        // original_dataset_id; this is a silent hygiene fix.)
         if (datasets.length > 0) {
-          await this.datasets.bulkPut(datasets);
+          const existing = await this.datasets.toArray();
+          const takenIdents = new Set(existing.map((d) => d.ident).filter(Boolean));
+          const datasetsToStore = datasets.map((d) => {
+            if (!d.ident) return d;
+            const sourceIdent = d.original_ident || d.ident;
+            const renamed = firstAvailable(d.ident, takenIdents, (base, n) => `${base}-${n}`);
+            takenIdents.add(renamed);
+            return { ...d, ident: renamed, original_ident: sourceIdent };
+          });
+          await this.datasets.bulkPut(datasetsToStore);
         }
 
         // Store clone metadata and separate heavy data using bulk operation

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -5,9 +5,19 @@
 import Dexie from "dexie";
 
 /**
+ * Maximum suffix attempts before firstAvailable gives up. Realistic uploads
+ * never approach this — a user accumulating 10000 same-named datasets is
+ * pathological. Bounded to make the failure mode loud rather than hung.
+ */
+const FIRST_AVAILABLE_MAX_ATTEMPTS = 10000;
+
+/**
  * Return the lowest-numbered candidate that doesn't appear in `taken`,
  * starting from the bare `base` and walking through `format(base, 1)`,
  * `format(base, 2)`, .... Pure helper, no DB access.
+ *
+ * Throws if a free candidate isn't found within FIRST_AVAILABLE_MAX_ATTEMPTS
+ * to fail loud rather than hang.
  *
  * @param {string} base
  * @param {Iterable<string>} taken
@@ -17,9 +27,11 @@ import Dexie from "dexie";
 export const firstAvailable = (base, taken, format) => {
   const set = new Set(taken);
   if (!set.has(base)) return base;
-  let n = 1;
-  while (set.has(format(base, n))) n += 1;
-  return format(base, n);
+  for (let n = 1; n <= FIRST_AVAILABLE_MAX_ATTEMPTS; n += 1) {
+    const candidate = format(base, n);
+    if (!set.has(candidate)) return candidate;
+  }
+  throw new Error(`firstAvailable: no free suffix found for "${base}" within ${FIRST_AVAILABLE_MAX_ATTEMPTS} attempts`);
 };
 
 /**
@@ -32,6 +44,11 @@ export const firstAvailable = (base, taken, format) => {
  * namespacing, two datasets with overlapping idents cross-talk in the UI and
  * (worse) overwrite each other in the trees table on insert. Namespacing at
  * the storage boundary keeps ident comparisons elsewhere unchanged.
+ *
+ * Constraint: source `ident` values must not contain the `::` separator.
+ * If they ever do, the round-trip back to `original_ident` becomes
+ * ambiguous. olmsted-cli outputs use UUIDs and dot-separated names that
+ * don't contain `::`, so this is currently safe.
  *
  * @param {string} datasetId - the (already-unique) storage dataset_id
  * @param {string} ident - the source ident
@@ -91,10 +108,15 @@ class OlmstedDB extends Dexie {
         // re-imports and sibling datasets — and ResizableTable derives
         // rowId from `datum.ident` before falling back to `datum.dataset_id`,
         // so collisions show up as hover/select cross-talk in the dataset
-        // tables. Auto-rename on collision to keep ident unique; preserve
-        // the original as `original_ident`. (The duplicate-upload modal
-        // already covers the user-facing "are you sure?" via
-        // original_dataset_id; this is a silent hygiene fix.)
+        // tables. Read the existing rows and rename to the next free
+        // `${ident}-{n}` on collision; preserve the original as
+        // `original_ident`.
+        //
+        // Note: this dedupe is *not* atomic across separate storeDataset
+        // calls — two parallel uploads could each see an empty `taken` set
+        // and pick the same renamed value. In practice fileUpload gates the
+        // UI behind `isProcessing`, so concurrent storeDataset is not
+        // currently reachable. Worth tightening if that ever changes.
         if (datasets.length > 0) {
           const existing = await this.datasets.toArray();
           const takenIdents = new Set(existing.map((d) => d.ident).filter(Boolean));
@@ -108,12 +130,17 @@ class OlmstedDB extends Dexie {
           await this.datasets.bulkPut(datasetsToStore);
         }
 
-        // Store clone metadata and separate heavy data using bulk operation
+        // Store clone metadata and separate heavy data using bulk operation.
+        // The clones map is keyed by storage dataset_id (the same `datasetId`
+        // we read off processedData), so cloneGroupId === datasetId for
+        // single-dataset uploads — but we keep the variable distinct from
+        // the outer `datasetId` to avoid silent drift if the data shape
+        // ever changes.
         const allCloneMeta = [];
-        for (const [dataset_id, cloneList] of Object.entries(clones)) {
+        for (const [cloneGroupId, cloneList] of Object.entries(clones)) {
           for (const clone of cloneList) {
             // Source idents are deterministic from olmsted-cli, so re-imports
-            // and sibling datasets often share idents. Namespace by dataset_id
+            // and sibling datasets often share idents. Namespace by datasetId
             // here so the byIdent lookup map, hover/star/select state, and the
             // trees-table primary key can't collide across datasets.
             const cloneOriginalIdent = clone.ident || clone.clone_id;
@@ -121,7 +148,7 @@ class OlmstedDB extends Dexie {
               ...clone,
               ident: namespacedIdent(datasetId, cloneOriginalIdent),
               original_ident: cloneOriginalIdent,
-              dataset_id: clone.dataset_id || dataset_id,
+              dataset_id: clone.dataset_id || cloneGroupId,
               sample_id: clone.sample_id || (clone.sample ? clone.sample.sample_id : null),
               name: clone.name || clone.clone_id,
               // Store tree metadata (lightweight, for dropdown display).

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -22,6 +22,23 @@ export const firstAvailable = (base, taken, format) => {
   return format(base, n);
 };
 
+/**
+ * Build a globally-unique ident by prefixing with the storage `dataset_id`.
+ *
+ * Source files (especially olmsted-cli output) emit deterministic clone and
+ * tree idents — re-importing the same source produces identical idents. The
+ * webapp uses `ident` as the per-row identity for selection, hover, starring,
+ * the byIdent lookup map, and the trees-table primary key. Without
+ * namespacing, two datasets with overlapping idents cross-talk in the UI and
+ * (worse) overwrite each other in the trees table on insert. Namespacing at
+ * the storage boundary keeps ident comparisons elsewhere unchanged.
+ *
+ * @param {string} datasetId - the (already-unique) storage dataset_id
+ * @param {string} ident - the source ident
+ * @returns {string}
+ */
+export const namespacedIdent = (datasetId, ident) => `${datasetId}::${ident}`;
+
 class OlmstedDB extends Dexie {
   constructor() {
     super("OlmstedClientStorage");
@@ -77,23 +94,33 @@ class OlmstedDB extends Dexie {
         const allCloneMeta = [];
         for (const [dataset_id, cloneList] of Object.entries(clones)) {
           for (const clone of cloneList) {
-            // Clone metadata — spread all fields to preserve custom data,
-            // then override fields that need normalization
+            // Source idents are deterministic from olmsted-cli, so re-imports
+            // and sibling datasets often share idents. Namespace by dataset_id
+            // here so the byIdent lookup map, hover/star/select state, and the
+            // trees-table primary key can't collide across datasets.
+            const cloneOriginalIdent = clone.ident || clone.clone_id;
             const cloneMeta = {
               ...clone,
-              ident: clone.ident || clone.clone_id,
+              ident: namespacedIdent(datasetId, cloneOriginalIdent),
+              original_ident: cloneOriginalIdent,
               dataset_id: clone.dataset_id || dataset_id,
               sample_id: clone.sample_id || (clone.sample ? clone.sample.sample_id : null),
               name: clone.name || clone.clone_id,
               // Store tree metadata (lightweight, for dropdown display).
               // tree.type is the legacy field name; coalesce onto tree.name on ingest.
+              // Tree idents get the same namespace prefix so the dropdown
+              // values match the (also-namespaced) trees-table primary keys.
               trees_meta: clone.trees
-                ? clone.trees.map((t) => ({
-                    ident: t.ident || t.tree_id,
-                    tree_id: t.tree_id,
-                    name: t.name || t.type,
-                    downsampling_strategy: t.downsampling_strategy
-                  }))
+                ? clone.trees.map((t) => {
+                    const treeOriginalIdent = t.ident || t.tree_id;
+                    return {
+                      ident: namespacedIdent(datasetId, treeOriginalIdent),
+                      original_ident: treeOriginalIdent,
+                      tree_id: t.tree_id,
+                      name: t.name || t.type,
+                      downsampling_strategy: t.downsampling_strategy
+                    };
+                  })
                 : clone.trees_meta || []
             };
             // Remove embedded trees array (stored separately)
@@ -106,10 +133,15 @@ class OlmstedDB extends Dexie {
           await this.clones.bulkPut(allCloneMeta);
         }
 
-        // Store complete tree data (like SessionStorage did) using bulk operation
+        // Store complete tree data (like SessionStorage did) using bulk operation.
+        // Tree idents get the same dataset_id prefix as clone idents — without
+        // it, two datasets whose source files share tree idents would collide
+        // on the trees-table primary key, with the second insert silently
+        // overwriting the first.
         const allTreeData = trees.map((tree) => ({
           tree_id: tree.tree_id,
-          ident: tree.ident,
+          ident: namespacedIdent(datasetId, tree.ident),
+          original_ident: tree.ident,
           clone_id: tree.clone_id,
           newick: tree.newick,
           root_node: tree.root_node,


### PR DESCRIPTION
## Summary

Three related fixes for problems that surface when more than one dataset shares identifiers (re-uploads, sibling datasets generated from the same source):

### 1. Duplicate-upload guard

Uploading the same source dataset twice — or two files that share an `original_dataset_id` — used to silently create duplicate entries in IndexedDB, because every upload generates a fresh storage `dataset_id`.

- **`olmstedDB`** picks up four helpers (`findDatasetByOriginalId`, `findDatasetByName`, `makeUniqueOriginalDatasetId`, `makeUniqueDatasetName`) backed by a pure `firstAvailable(base, taken, format)` function.
- **`DuplicateIdWarningModal`** — shown when the new dataset's `original_dataset_id` matches one already loaded. Names the existing dataset; user can cancel or save as a separate dataset.
- **`DuplicateNameModal`** — shown when the new dataset's display name matches one already loaded. Pre-fills with `{name} (n)`. User can edit, accept, or keep the duplicate name (soft warning only).
- **`fileUpload.js`** runs `resolveDuplicateConflicts` between processing and storing for both the single-file and split-file paths. Modals pause the upload via promise-resolving state.
- Hover-aware **`ModalButton`** with three semantic variants (primary blue, warning amber outline, neutral gray); raw `dataset_id` values are not exposed in the user-facing copy.

### 2. Namespace idents at storage

Source files (especially olmsted-cli output) emit deterministic clone and tree idents — re-imports and sibling datasets share them. The webapp keys hover, star, select, the `byIdent` lookup map, and the trees-table primary key on bare ident, so two datasets with overlapping idents cross-talk in the UI and (worse) overwrite each other in the trees table on insert.

- New `namespacedIdent(datasetId, ident)` helper: `${datasetId}::${ident}`.
- `olmstedDB.storeDataset` rewrites `clone.ident`, the `trees_meta` projection on each clone, and `tree.ident` to the namespaced form. Source idents are preserved as `original_ident` for display.
- **Dataset records** also carry an `ident` field (separate from `dataset_id`). `ResizableTable` derives `rowId = datum.id || datum.ident || datum.dataset_id || index`, so collisions on dataset `ident` cause hover/select cross-talk in the Dataset Management and Dataset Loading tables. `storeDataset` now silently auto-renames colliding dataset `ident`s via the same `firstAvailable` suffix walk used for `original_dataset_id`. (Longer-term: consolidate `ident` and `dataset_id` into a single field.)
- Two display sites prefer `original_ident` over the storage ident (`RowInfoModal` title fallback, `IncompleteDataWarning` ID fallback). Everything else keeps working unchanged because the value coming back from IndexedDB **is** the namespaced ident.

### 3. Restore legacy `"internal"` node-type compatibility

The earlier Vega sweep on PR #280 dropped the `'internal'` branch from a Vega filter on the assumption that nothing in the current pipeline emits it. That was wrong — `pcp-byhand-olmsted-golden.json` (and likely other older olmsted-cli outputs) still tags intermediate nodes with `"internal"`, and the dropped branch caused those nodes to be filtered out. Symptom: internal-node tooltips/selectable dots stopped rendering in the tree visualization.

- `fileProcessor.processConsolidatedFormat` now coalesces `node.type === "internal"` to `NODE_TYPES.NODE` on ingest, so downstream selectors and Vega filters keep seeing only the canonical value.

## Migration note

Existing IndexedDB data uploaded before this change retains bare idents and won't pick up the namespace fix until **cleared and re-uploaded** (in-app "Delete ALL Data" button on the splash screen does this).

## Test plan

- [x] `npm test` — 599 tests across 29 suites, all passing (4 for `firstAvailable`, 3 for `namespacedIdent`, 1 for `internal`→`node` coalesce)
- [x] `npx prettier --check` and `npx eslint` on touched files — clean (pre-existing warnings only)
- [x] Manual QA: with two datasets loaded that share clone idents (`pcp-byhand-A`/`pcp-byhand-B` in `_data/pcp-test/`), hover/select in one dataset's family table no longer highlights rows in the other.
- [x] Manual QA: same setup, hover/select in the Dataset Management and Dataset Loading tables no longer cross-talk.
- [x] Manual QA: same setup, click into the same logical family in each dataset → trees render distinctly (verified by mutating one leaf's sequence in B; A and B show different alignments).
- [x] Manual QA: internal-node tooltips/selectable dots render in tree viz with pcp-byhand data.
- [x] Manual QA: re-upload the same dataset → "Possible duplicate" modal names the existing entry; "Cancel upload" aborts; "Save as separate dataset" saves with a renamed source id.
- [x] Manual QA: upload a dataset whose name matches an existing one → name modal appears with `{name} (1)` pre-filled; "Use this name" accepts; clearing back to the duplicate shows the soft warning and "Keep duplicate name" still works.
- [x] Manual QA: confirm the split-file upload path also presents the modals when there's a collision.

🤖 Generated with [Claude Code](https://claude.com/claude-code)