### PR TITLE
Add PRE-MERGE-CHECKLIST.md and DESIGN.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## version 2.7.5 - 2026/05/22
+Changed:
+* Added `DESIGN.md` (load-bearing architectural decisions as guardrails) and `PRE-MERGE-CHECKLIST.md` (16-step quality gate for PRs). Slimmed the inline Pre-PR checklist in `CLAUDE.md` to a pointer at the new checklist.
+
 ## version 2.7.4 - 2026/05/22
 Changed:
 * Dependency bumps (supersedes dependabot PRs #275, #276, #284, #288, #289, #290, #295): uuid 13 → 14, webpack-dev-server 5.2.3 → 5.2.4, postcss 8.5.8 → 8.5.15, fast-uri 3.1.0 → 3.1.2, @xmldom/xmldom 0.8.12 → 0.8.13, ip-address 10.1.0 → 10.2.0, @babel/plugin-transform-modules-systemjs 7.29.0 → 7.29.4. All patch/minor except uuid (major, but uuid isn't imported anywhere in `src/` — the bump is effectively a lockfile-only change).

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -34,14 +34,18 @@ olmsted/
 ├── data/                     # Local data directory (gitignored)
 ├── docs/                     # Documentation images
 ├── ARCHITECTURE.md           # System architecture documentation
+├── DESIGN.md                 # Load-bearing architectural decisions (guardrails)
 ├── DEVELOPMENT.md            # Developer onboarding guide
+├── PRE-MERGE-CHECKLIST.md    # Quality gates required before opening a PR
 └── CLAUDE.md                 # This file
 ```
 
 ## Design Documents
 
+- **[DESIGN.md](./DESIGN.md)**: Load-bearing architectural decisions and guardrails (read this before proposing structural changes)
 - **[ARCHITECTURE.md](./ARCHITECTURE.md)**: Data flow, Redux store structure, component hierarchy, Vega integration
 - **[DEVELOPMENT.md](./DEVELOPMENT.md)**: Setup guide, common tasks, debugging, build process
+- **[PRE-MERGE-CHECKLIST.md](./PRE-MERGE-CHECKLIST.md)**: Required quality gates before opening a PR
 
 ## Development Environment
 
@@ -95,17 +99,7 @@ npm start
 
 ### Pre-PR Quality Checklist
 
-Before any pull request:
-
-1. **Format Code**: Run `npm run format`
-2. **Lint Check**: Run `npm run lint` and address errors
-3. **Test Locally**: Verify changes work in browser
-4. **Documentation**: Update JSDoc for modified functions
-5. **Update Project Documentation**: Keep these files current:
-   - `CLAUDE.md` - Update if adding new patterns, lessons learned, or terminology
-   - `ARCHITECTURE.md` - Update if changing data flow, Redux store, or component hierarchy
-   - `DEVELOPMENT.md` - Update if changing setup, scripts, or common workflows
-   - `CHANGELOG.md` - Add entry for user-facing changes
+See **[PRE-MERGE-CHECKLIST.md](./PRE-MERGE-CHECKLIST.md)** for the full checklist (format, lint, tests, build, browser smoke test, code-standards review, Vega/IndexedDB/field-metadata gates, documentation sync, and PR description quality). If you find the checklist wrong or incomplete during a PR, update it as part of the PR.
 
 ## Terminology
 
@@ -133,7 +127,7 @@ Before any pull request:
 
 - **Brush Selection**: Interactive selection by clicking/dragging on scatterplot
 - **Faceting**: Splitting visualization into panels by a categorical variable
-- **Split Format**: Server-side data format with separate files for datasets, clones, and trees
+- **Split Format**: Client-side multi-file upload format (datasets, clones, and trees uploaded as separate files via the browser). Handled by `src/utils/splitFileProcessor.js`. The earlier server-side variant was removed in PR #296.
 
 ## Deployment Architecture
 
@@ -182,4 +176,4 @@ The public website is **NOT served from Docker**:
 
 ---
 
-*Last updated: 2026-03-28*
+*Last updated: 2026-05-07*

--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,153 @@
+# Olmsted Design
+
+Load-bearing architectural decisions for the Olmsted web application.
+Where [ARCHITECTURE.md](./ARCHITECTURE.md) describes *what the system is* and
+[DEVELOPMENT.md](./DEVELOPMENT.md) describes *how to work in it*, this
+document describes *what we will not change without justification*.
+
+These decisions are guardrails. A proposed feature or PR that conflicts
+with one should either justify the exception in the PR body or be revised.
+ARCHITECTURE.md is the place to look up *how* a decision is implemented;
+this document only states the decision and why future work should respect it.
+
+---
+
+## D1. Client-Side Only
+
+The deployed application performs no server-side data processing. The
+public instance at olmstedviz.org is static files on S3 + CloudFront; the
+Docker image is for self-hosted convenience and serves the same client
+bundle. Uploaded data lives in the user's browser (IndexedDB) and is
+never transmitted.
+
+This is a privacy and operational simplicity guarantee. Do not add
+features that require a backend round-trip for the deployed app. If a
+new analysis genuinely needs server compute, it belongs upstream in
+[olmsted-cli](https://github.com/matsengrp/olmsted-cli), not in this
+repository.
+
+The `npm run start:local` server mode is a development convenience that
+serves consolidated olmsted-cli JSON files from a local directory; it is
+not a deployment target.
+
+## D2. Redux Store as Single Source of Truth, URL as Mirror
+
+Application state lives in Redux. The browser URL mirrors a defined
+subset of that state via `changeURLMiddleware`
+(`src/middleware/changeURL.js`), enabling deep linking and browser
+navigation. The URL is downstream of Redux, never the other way around.
+
+New persistent UI state (selections, filters, view options) goes through
+a reducer. Don't store it in component state if it should survive
+navigation, and don't read it from the URL outside the middleware.
+
+## D3. Vega Specs Behind a Single Wrapper
+
+All charts are Vega 6 specs rendered through `VegaChart`
+(`src/components/util/VegaChart.js`). `VegaChart` owns the
+react-vega v8 boundary: data merging at embed time and post-embed updates
+via `view.change()` (preserves zoom/pan/brush). The only way to obtain a
+`view` reference is through the `onNewView` callback that `VegaChart`
+exposes. Once captured, the view may be stored (e.g. in React context,
+as `tree.js` does via `setTreeView`) and used to attach signal listeners
+later for cross-component coordination. Do not reach for a view by other
+means (no `document.querySelector` on the Vega DOM, no `embed()` calls
+from feature code).
+
+Do not import `react-vega` directly in feature code, and do not bypass
+`VegaChart` to call `view.change()` from a component. The wrapper exists
+because react-vega v8 removed the v4 API the codebase was built against;
+the indirection is what lets us upgrade Vega without rewriting every
+chart.
+
+## D4. Persistence: IndexedDB via Dexie + In-Memory Cache
+
+Datasets persist in IndexedDB (`OlmstedClientStorage` database, managed
+through Dexie in `src/utils/olmstedDB.js`). Two 10-item FIFO caches in
+`src/utils/clientDataStore.js` (one for clones, one for trees) sit in
+front of IndexedDB to amortize repeat reads. Eviction is insertion-order;
+hits do not refresh position.
+
+Cross-dataset isolation is enforced by `namespacedIdent(datasetId,
+ident)` in `src/utils/olmstedDB.js`, which prefixes every stored
+clone/tree key with its dataset_id. New entities stored alongside clones
+or trees must namespace their keys the same way; failing to do so causes
+silent cross-dataset bleed (see PR #283).
+
+Do not invent a parallel storage path. Schema changes increment the
+Dexie version and ship with a migration tested against an existing
+database. Schema changes are also documented in the ARCHITECTURE.md
+"IndexedDB Schema" section.
+
+## D5. Lazy Loading by Default
+
+Dataset metadata is loaded eagerly. Clone metadata is loaded when a
+dataset is selected. Tree node data is loaded only when a specific
+family is opened. This is what makes thousand-family datasets usable in
+the browser.
+
+Don't pre-load tree data "for responsiveness" or "to simplify the
+component" — the user pays for that in tab memory and IndexedDB read
+volume. New code that consumes tree data should request a single tree
+through `getClientTree(...)` and tolerate the async boundary.
+
+## D6. Field Metadata Drives the UI
+
+Visualization controls (scatterplot axis dropdowns, color encodings,
+tooltips, table columns) are populated from `field_metadata` shipped in
+the Olmsted JSON, mediated by `src/utils/fieldMetadata.js`. Two adjacent
+files split the defaults by concern, and confusing them is a recurring
+papercut:
+
+- `src/constants/fieldDefaults.js` — display metadata (labels, types,
+  display modes, the `DEFAULT_CLONE_FIELDS` / `BUILTIN_NODE_FIELDS` tables).
+- `src/utils/fieldDefaults.js` — per-field data defaults
+  (`NODE_FIELD_DEFAULTS`, `CLONE_FIELD_DEFAULTS`) and the `REQUIRED`
+  sentinel that distinguishes mandatory fields (validation error at
+  import) from optional ones (defaulted at import).
+
+Do not hardcode field names into Vega specs or components when those
+fields are dataset-supplied. Adding a new field means registering it in
+the field metadata pipeline, not adding another conditional branch in a
+component.
+
+## D7. Constants Module, Not Inline Literals
+
+Categorical values that the UI compares against (chain types, loci,
+node types, display labels, color scales) live in `src/constants/`.
+Inline string literals like `"heavy"`, `"light"`, `"naive"`, `"leaf"`
+in components and specs are the reason recent PRs have included
+"constants sweep" cleanup work (see PR #280).
+
+When you add a new categorical value, add it to the appropriate constants
+file and import it. When you read one, import the constant rather than
+hand-typing the string.
+
+## D8. Forest Trees Become a Single Tree at the Selector Boundary
+
+Some upstream pipelines produce forests (multiple disconnected
+subtrees). The visualization assumes a single rooted tree. The
+`ensureSingleRoot()` / `normalizeTreeNodes()` helpers in
+`src/selectors/trees.js` reconcile these by removing empty placeholder
+roots, or — for true forests — synthesizing a `__synthetic_root__` with
+a consensus sequence. The transformation is recorded in
+`data_modifications` and surfaced as a user-visible warning.
+
+Tree-consuming code downstream of these selectors may assume a single
+root. Forest reconciliation is not optional and is not the consumer's
+responsibility; route new tree consumers through the existing
+selectors rather than walking raw `nodes` arrays.
+
+## D9. Olmsted JSON Is the Input Contract
+
+The web app consumes Olmsted JSON only. Conversion from AIRR, PCP, or
+other repertoire formats happens in
+[olmsted-cli](https://github.com/matsengrp/olmsted-cli) and is out of
+scope for this repository. The web app validates structure
+(`metadata`, `datasets`, `clones`, `trees`) at import time and refuses
+malformed input rather than coping silently.
+
+When the input contract evolves, the change is coordinated with
+olmsted-cli and the format documentation, and is reflected in the
+CHANGELOG. Don't add ad-hoc fallbacks for "older" or "alternative" JSON
+shapes — they accumulate forever.

--- a/PRE-MERGE-CHECKLIST.md
+++ b/PRE-MERGE-CHECKLIST.md
@@ -1,0 +1,38 @@
+# Pre-Merge Quality Checklist
+
+Companion to [DESIGN.md](./DESIGN.md) (load-bearing architectural choices) and
+[ARCHITECTURE.md](./ARCHITECTURE.md) (descriptive system documentation).
+
+If you discover this checklist is wrong or incomplete during a PR, update it as part of the PR.
+
+Before any pull request:
+
+1. **Format**: `npm run format`, then `npm run format:check` to verify a clean diff.
+2. **Lint**: `npm run lint`. Address every error. `console.log` is configured as a warning (not an error, so it won't fail this step) but should still be removed before merge — only `console.warn` and `console.error` are allowed by the project's ESLint rules.
+3. **Tests**: `npm test` runs the full Jest suite (~10s, ~650 tests). The suite is small enough that there's no benefit to running subsets locally; CI runs it on every push regardless. If you add new behavior, add tests in the colocated `__tests__/` directory (see [DEVELOPMENT.md](./DEVELOPMENT.md#testing)).
+4. **Build**: `npm run build` (production webpack). This catches import errors, JSX issues, and dependency mismatches that pure lint/test runs miss because of the Babel-jest transform pipeline. CI builds the Docker image — a local build failure is a guaranteed CI failure.
+5. **Browser smoke test**: With `npm start`, exercise the three flows end-to-end in a real browser. The Vega rendering layer is not exercised in headless tests beyond spec parse + headless View; visual regressions and signal-listener bugs only show up here.
+   - **Upload**: drop an Olmsted JSON file on the splash page. Confirm the dataset appears in the management table without errors.
+   - **Scatterplot + table**: load a dataset, brush-select families, page through the table, sort a column, change facet/locus.
+   - **Tree + lineage**: select a family, verify tree renders, click a node, open lineage, toggle subtree-as-root focus and back to full tree.
+   - If you can't run the UI for a given change (e.g., pure docs/CI work), say so explicitly in the PR description rather than claiming this step passed.
+6. **Background code review** (launch now, read results later): Spawn the `clean-code-reviewer` agent on changed source files in parallel with the rest of this checklist. For PRs with new visualization code, also spawn `plot-reviewer` on changed Vega specs. Agent definitions live at [matsen/bipartite](https://github.com/matsen/bipartite/tree/main/agents). Read results before merging.
+7. **Code standards** (see [CLAUDE.md](./CLAUDE.md)):
+   - **Function size**: no function exceeds 50 lines. Refactor before merge.
+   - **No inline TODOs**: file a GitHub issue instead. ESLint won't catch this — grep for `TODO|FIXME|HACK` in the diff.
+   - **JSDoc** for new public functions and any non-obvious exported helper.
+   - **Naming**: camelCase with verb prefixes for functions (`get`, `set`, `handle`, `process`, `validate`).
+8. **Constants**: New categorical values (chain types, locus values, node types, color schemes, display labels) belong in `src/constants/`, not as inline string literals in components or specs. See DESIGN.md D7.
+9. **Field metadata**: If you add a new clone or node field, register it through the field metadata pipeline rather than reading it directly off objects in components or selectors. See DESIGN.md D6 and `src/utils/fieldDefaults.js` / `src/utils/fieldMetadata.js`. Required fields use the `REQUIRED` sentinel; optional fields need a default in `NODE_FIELD_DEFAULTS` or `CLONE_FIELD_DEFAULTS`.
+10. **Vega specs**: If the PR touches anything in `src/components/explorer/vega/`, render the affected spec at least once in the browser at full data volume (not just the unit fixtures). Vega errors at runtime are usually silent in the console — watch for empty marks, broken legends, or missing tooltips. All chart components must render through `VegaChart` (`src/components/util/VegaChart.js`); do not import `react-vega` directly. See DESIGN.md D3.
+11. **IndexedDB schema**: If the PR changes the Dexie schema (`src/utils/olmstedDB.js`), increment the version number and add a migration. Test by loading the app with an existing database from the previous version — uncaught migration bugs corrupt user data silently. Document the schema change in the ARCHITECTURE.md "IndexedDB Schema" section and the CHANGELOG.
+12. **Performance posture**: The lazy loading strategy (datasets always, clones on selection, trees on demand) and the two 10-item FIFO caches in `clientDataStore.js` (one for clones, one for trees) are load-bearing for large datasets. Don't bypass them — e.g., don't pre-load all trees on dataset selection, don't store full tree data in Redux for "convenience". See DESIGN.md D4 and D5.
+13. **Documentation sync**: Update each of these only when relevant:
+    - **CLAUDE.md** — new patterns, terminology, or lessons learned.
+    - **ARCHITECTURE.md** — changes to data flow, Redux store shape, component hierarchy, IndexedDB schema, or Vega integration. ARCHITECTURE.md describes the system as it *is*.
+    - **DESIGN.md** — only if the PR introduces or revises a load-bearing architectural decision. DESIGN.md describes guardrails for what future PRs may *not* do without justification.
+    - **DEVELOPMENT.md** — changes to setup, scripts, build pipeline, or test conventions.
+    - **CHANGELOG.md** — every user-facing change. Match the existing version-block format.
+14. **Dependencies**: If the PR adds or upgrades a dependency, run `npm audit` and address any new high/critical findings (or note them in the PR body if they're transitive and already-known). Do not introduce `--legacy-peer-deps`; if a peer dependency conflict surfaces, resolve it via `overrides` in `package.json` and explain in the CHANGELOG why.
+15. **Background review results**: Read the agent results from step 6 and address findings. If they cause code changes, re-run steps 1–4 on the final code.
+16. **PR description**: After any rebase, re-read the squashed diff and rewrite the PR body to describe the *final* state, not the commit history. Include the CHANGELOG entry's user-facing summary in the body. If you intentionally skipped any step above (e.g., browser smoke test for a docs-only PR), state which and why.

--- a/src/utils/clientDataStore.js
+++ b/src/utils/clientDataStore.js
@@ -284,7 +284,7 @@ class ClientDataStore {
 
   /**
    * Add item to cache with size limit.
-   * Implements LRU (Least Recently Used) eviction when cache exceeds maxCacheSize.
+   * Implements FIFO (insertion-order) eviction when cache exceeds maxCacheSize.
    * @private
    * @param {Map<string, any>} cache - Cache map to add to
    * @param {string} key - Cache key


### PR DESCRIPTION
## Summary

- **PRE-MERGE-CHECKLIST.md** — modeled on the phyz checklist but tailored to a React/Redux/Vega web app. 16 steps: format, lint, full Jest suite, production webpack build, browser smoke test, background code review, plus gates specific to constants, field metadata, Vega specs, the IndexedDB schema, lazy loading, dependencies, doc sync, and PR description quality.
- **DESIGN.md** — load-bearing architectural decisions as guardrails: client-side only, Redux + URL middleware, Vega behind the `VegaChart` wrapper, Dexie + LRU persistence, lazy tree loading, field-metadata-driven UI, the constants module, forest reconciliation at the selector boundary, and the Olmsted JSON input contract.
- **CLAUDE.md** — replaces the inline 5-line Pre-PR checklist with a pointer to PRE-MERGE-CHECKLIST.md, and lists DESIGN.md alongside ARCHITECTURE.md / DEVELOPMENT.md / PRE-MERGE-CHECKLIST.md under "Design Documents".

## Why DESIGN.md is not redundant with ARCHITECTURE.md

ARCHITECTURE.md is **descriptive** ("this is how data flows, this is the store shape, these are the components"). DESIGN.md is **prescriptive** ("future PRs should not bypass these choices without justification"). DESIGN.md is intentionally short and cross-references ARCHITECTURE.md for implementation detail rather than restating it; if the only thing a section would say is "see ARCHITECTURE.md," I dropped it.

## Follow-up

Codebase debt items surfaced while writing DESIGN.md but out of scope for this PR have been filed as #286 (globals.js dead code, `src/util/` vs `src/utils/` split, CLAUDE.md "modern patterns" aspirational language).

## Test plan

- [x] Markdown renders correctly in the GitHub preview
- [x] PR reviewers (human) sanity-check the load-bearing decisions in DESIGN.md against their mental model of the project — flag anything that's stated as a guardrail but is actually negotiable, or anything genuinely load-bearing that's missing
- [x] PR reviewers (human) check the PRE-MERGE-CHECKLIST.md against a recent PR or two — does it catch the kinds of issues that have actually slipped through?

🤖 Generated with [Claude Code](https://claude.com/claude-code)