### PR TITLE
Server-side test harness for Charon API + local-data workflow docs

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,58 +71,81 @@ Starts the development server at `http://localhost:3999` with:
 
 ### With Local Data (Server Mode)
 
-For testing with local data files in split format:
+The dev server can serve dataset files from a local directory at `/data/*`
+instead of fetching them from a remote bucket. This is what the production
+build does for the static "server-side" datasets (currently legacy auspice
+output on olmstedviz.org).
 
 ```bash
-# Copy example data to data/ directory
-cp ../olmsted-cli/example_data/pcp/split_golden_data/* path/to/data/
-
-# Start development server with hot reloading
-./bin/olmsted-server-local.sh /path/to/data 3999 dev
-
-# OR: invoke npm scripts manually
-
-# Start with local data
-npm run start:local
-# Or specify a custom data directory:
-BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData data
+# Point start:local at a directory containing the server-side files:
+npm run start:local _data/server-snapshot/
 ```
 
-**Note**: Local data mode requires **split format** (separate files for datasets, clones, trees), not the consolidated single-file format used for browser uploads.
+Equivalent long form:
+
+```bash
+BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData _data/server-snapshot/
+```
+
+The directory must contain files at these paths (root-level, no nesting):
+
+| File                       | Purpose                                         |
+| -------------------------- | ----------------------------------------------- |
+| `datasets.json`            | Manifest — array of dataset metadata objects    |
+| `clones.{dataset_id}.json` | Per-dataset clone list (one file per dataset)   |
+| `tree.{tree_ident}.json`   | Per-tree full payload (one file per tree ident) |
+
+This is **distinct from** the consolidated single-file upload format used
+by the browser uploader (`.json` / `.json.gz` containing a single
+`{ metadata, datasets, clones, trees }` object).
+
+### Snapshot of the production server datasets
+
+To produce a local copy of the currently-deployed olmstedviz.org datasets
+(useful for offline dev and manual QA of the server-side flow):
+
+```bash
+python3 _ignore/snapshot-server-data.py
+```
+
+The script crawls `http://www.olmstedviz.org/data/` starting from the
+manifest and writes everything to `_data/server-snapshot/`
+(~780 MB, gitignored). Once it finishes you can run
+`npm run start:local _data/server-snapshot/` against it.
 
 ---
 
 ## Available Scripts
 
-| Command                 | Description                                                                                        |
-| ----------------------- | -------------------------------------------------------------------------------------------------- |
-| `npm start`             | Start development server with hot reloading                                                        |
-| `npm run start:local`   | Start with local data from `data/` directory (see [With Local Data](#with-local-data-server-mode)) |
-| `npm run build`         | Full production build — runs `build:client` + `build:server`                                       |
-| `npm run build:client`  | Build the production web bundle to `_deploy/dist/`                                                 |
-| `npm run build:server`  | Build the production Express server bundle to `server.dist.js`                                     |
-| `npm run build:electron`| Build the Electron renderer bundle to `dist/`                                                      |
-| `npm run build:start`   | Build and start production server                                                                  |
-| `npm run run:electron`  | Build the Electron bundle and launch the packaged app locally                                      |
-| `npm run dist:electron` | Package a platform-specific Electron distributable (AppImage on Linux, `.dmg` on macOS) into `_releases/` |
-| `npm run lint`          | Run ESLint on src/                                                                                 |
-| `npm run format`        | Format code with Prettier                                                                          |
-| `npm run format:check`  | Check formatting without modifying files                                                           |
-| `npm test`              | Run all Jest tests                                                                                 |
-| `npm run test:watch`    | Run tests in watch mode (re-runs on file changes)                                                  |
-| `npm run test:coverage` | Run tests with coverage report                                                                     |
-| `npm run clean`         | Remove build artifacts                                                                             |
+| Command                  | Description                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `npm start`              | Start development server with hot reloading                                                               |
+| `npm run start:local`    | Start with local data from `data/` directory (see [With Local Data](#with-local-data-server-mode))        |
+| `npm run build`          | Full production build — runs `build:client` + `build:server`                                              |
+| `npm run build:client`   | Build the production web bundle to `_deploy/dist/`                                                        |
+| `npm run build:server`   | Build the production Express server bundle to `server.dist.js`                                            |
+| `npm run build:electron` | Build the Electron renderer bundle to `dist/`                                                             |
+| `npm run build:start`    | Build and start production server                                                                         |
+| `npm run run:electron`   | Build the Electron bundle and launch the packaged app locally                                             |
+| `npm run dist:electron`  | Package a platform-specific Electron distributable (AppImage on Linux, `.dmg` on macOS) into `_releases/` |
+| `npm run lint`           | Run ESLint on src/                                                                                        |
+| `npm run format`         | Format code with Prettier                                                                                 |
+| `npm run format:check`   | Check formatting without modifying files                                                                  |
+| `npm test`               | Run all Jest tests                                                                                        |
+| `npm run test:watch`     | Run tests in watch mode (re-runs on file changes)                                                         |
+| `npm run test:coverage`  | Run tests with coverage report                                                                            |
+| `npm run clean`          | Remove build artifacts                                                                                    |
 
 ### Build Pipeline
 
 Olmsted has two distribution channels that share the same React source but use different webpack configs. Both go through Babel for JSX/ESNext transpilation.
 
-| Config                        | Used by                     | Output                          | Purpose                            |
-| ----------------------------- | --------------------------- | ------------------------------- | ---------------------------------- |
-| `webpack.config.dev.js`       | `npm start`                 | `_devel/` (in-memory via HMR)   | Hot-reloading dev server           |
-| `webpack.config.prod.js`      | `npm run build:client`      | `_deploy/dist/bundle.js`        | Production web bundle (S3/Docker)  |
-| `webpack.config.server.js`    | `npm run build:server`      | `server.dist.js`                | Bundled Express server             |
-| `webpack.config.electron.js`  | `npm run build:electron`    | `dist/bundle.js`                | Renderer for the Electron app      |
+| Config                       | Used by                  | Output                        | Purpose                           |
+| ---------------------------- | ------------------------ | ----------------------------- | --------------------------------- |
+| `webpack.config.dev.js`      | `npm start`              | `_devel/` (in-memory via HMR) | Hot-reloading dev server          |
+| `webpack.config.prod.js`     | `npm run build:client`   | `_deploy/dist/bundle.js`      | Production web bundle (S3/Docker) |
+| `webpack.config.server.js`   | `npm run build:server`   | `server.dist.js`              | Bundled Express server            |
+| `webpack.config.electron.js` | `npm run build:electron` | `dist/bundle.js`              | Renderer for the Electron app     |
 
 ```bash
 # Full production build (web)
@@ -279,13 +302,13 @@ Import shared mock data from `src/__test-data__/mockState.js` rather than duplic
 
 ### Configuration
 
-| File                    | Purpose                                                                                                                                   |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `jest.config.js`        | Jest config: jsdom env, babel-jest transform, CSS/image mocks, ESM package handling, `setupFilesAfterEnv` for `@testing-library/jest-dom` |
-| `jest.setup.js`         | `fake-indexeddb/auto` polyfill, `structuredClone` polyfill for Node 18, sessionStorage fallback, console noise suppression                |
-| `__mocks__/fileMock.js` | Stub for image/file imports                                                                                                               |
-| `.babelrc` `"test"` env | Avoids loading react-refresh plugin (crashes in Jest)                                                                                     |
-| `eslint.config.mjs` test override | Adds Jest globals for `__tests__/` files so ESLint recognizes `describe`, `it`, `expect`, etc.                                  |
+| File                              | Purpose                                                                                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `jest.config.js`                  | Jest config: jsdom env, babel-jest transform, CSS/image mocks, ESM package handling, `setupFilesAfterEnv` for `@testing-library/jest-dom` |
+| `jest.setup.js`                   | `fake-indexeddb/auto` polyfill, `structuredClone` polyfill for Node 18, sessionStorage fallback, console noise suppression                |
+| `__mocks__/fileMock.js`           | Stub for image/file imports                                                                                                               |
+| `.babelrc` `"test"` env           | Avoids loading react-refresh plugin (crashes in Jest)                                                                                     |
+| `eslint.config.mjs` test override | Adds Jest globals for `__tests__/` files so ESLint recognizes `describe`, `it`, `expect`, etc.                                            |
 
 **Key dependencies:**
 

--- a/src/server/__tests__/__fixtures__/server-data/clones.fixture-dataset-001.json
+++ b/src/server/__tests__/__fixtures__/server-data/clones.fixture-dataset-001.json
@@ -1,0 +1,16 @@
+[
+  {
+    "clone_id": "fixture-clone-001",
+    "dataset_id": "fixture-dataset-001",
+    "ident": "fixture-clone-001",
+    "trees": [
+      {
+        "ident": "fixture-tree-001",
+        "tree_id": "min_adcl-raxml_ng",
+        "clone_id": "fixture-clone-001",
+        "type": "cft.reconstruction",
+        "downsampling_strategy": "min_adcl"
+      }
+    ]
+  }
+]

--- a/src/server/__tests__/__fixtures__/server-data/datasets.json
+++ b/src/server/__tests__/__fixtures__/server-data/datasets.json
@@ -1,0 +1,11 @@
+[
+  {
+    "ident": "fixture-ident-001",
+    "dataset_id": "fixture-dataset-001",
+    "clone_count": 1,
+    "subjects_count": 1,
+    "timepoints_count": 1,
+    "schema_version": "2.0.0",
+    "name": "Fixture dataset"
+  }
+]

--- a/src/server/__tests__/__fixtures__/server-data/tree.fixture-tree-001.json
+++ b/src/server/__tests__/__fixtures__/server-data/tree.fixture-tree-001.json
@@ -1,0 +1,11 @@
+{
+  "ident": "fixture-tree-001",
+  "tree_id": "min_adcl-raxml_ng",
+  "clone_id": "fixture-clone-001",
+  "newick": "(A:1,B:1)naive:0;",
+  "nodes": {
+    "naive": { "type": "root", "parent": null },
+    "A": { "type": "leaf", "parent": "naive" },
+    "B": { "type": "leaf", "parent": "naive" }
+  }
+}

--- a/src/server/__tests__/charon.test.js
+++ b/src/server/__tests__/charon.test.js
@@ -1,0 +1,105 @@
+/**
+ * Route-level tests for src/server/charon.js
+ *
+ * The charon module wires `/charon/*` requests to the appropriate
+ * getFiles handler based on the `request` query parameter. We capture
+ * the handler registered with the mock Express app and invoke it
+ * directly with various query strings.
+ */
+
+jest.mock("../getFiles", () => ({
+  getDatasets: jest.fn(async () => {}),
+  getClonalFamilies: jest.fn(async () => {}),
+  getSplashImage: jest.fn(async () => {}),
+  getDatasetJson: jest.fn(async () => {})
+}));
+
+const getFiles = require("../getFiles");
+const charon = require("../charon");
+
+const makeRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn(),
+  headersSent: false
+});
+
+// Capture the handler registered for the /charon route.
+const captureHandler = () => {
+  let handler;
+  charon.applyCharonToApp({
+    get: (_path, fn) => {
+      handler = fn;
+    }
+  });
+  return handler;
+};
+
+describe("charon route", () => {
+  let handler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = captureHandler();
+  });
+
+  it.each([
+    ["datasets", "getDatasets"],
+    ["clonalFamilies", "getClonalFamilies"],
+    ["splashimage", "getSplashImage"],
+    ["json", "getDatasetJson"]
+  ])("dispatches request=%s to %s", async (request, handlerName) => {
+    const res = makeRes();
+    await handler({ originalUrl: `/charon?request=${request}`, url: `/charon?request=${request}` }, res);
+    expect(getFiles[handlerName]).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the parsed query through to the handler", async () => {
+    const res = makeRes();
+    const url = "/charon?request=json&path=clones.fixture-dataset-001.json&s3=staging";
+    await handler({ originalUrl: url, url }, res);
+    expect(getFiles.getDatasetJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: "json",
+        path: "clones.fixture-dataset-001.json",
+        s3: "staging"
+      }),
+      res
+    );
+  });
+
+  it("silently ignores requests with no `request` query param", async () => {
+    const res = makeRes();
+    await handler({ originalUrl: "/charon", url: "/charon" }, res);
+    expect(getFiles.getDatasets).not.toHaveBeenCalled();
+    expect(getFiles.getClonalFamilies).not.toHaveBeenCalled();
+    expect(getFiles.getSplashImage).not.toHaveBeenCalled();
+    expect(getFiles.getDatasetJson).not.toHaveBeenCalled();
+  });
+
+  it("silently ignores requests with an unknown `request` value", async () => {
+    const res = makeRes();
+    await handler({ originalUrl: "/charon?request=unknown", url: "/charon?request=unknown" }, res);
+    expect(getFiles.getDatasets).not.toHaveBeenCalled();
+    expect(getFiles.getClonalFamilies).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the handler throws and headers haven't been sent", async () => {
+    getFiles.getDatasets.mockImplementationOnce(async () => {
+      throw new Error("oops");
+    });
+    const res = makeRes();
+    await handler({ originalUrl: "/charon?request=datasets", url: "/charon?request=datasets" }, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith("Internal server error");
+  });
+
+  it("does not double-send when the handler throws after headers were sent", async () => {
+    getFiles.getDatasets.mockImplementationOnce(async () => {
+      throw new Error("oops");
+    });
+    const res = { ...makeRes(), headersSent: true };
+    await handler({ originalUrl: "/charon?request=datasets", url: "/charon?request=datasets" }, res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/getFiles.test.js
+++ b/src/server/__tests__/getFiles.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for src/server/getFiles.js
+ *
+ * Covers the file-serving layer used by the Charon API:
+ * - validateFilePath rejects traversal and absolute paths (tested
+ *   indirectly through getSplashImage / getDatasetJson, which surface
+ *   the validation errors).
+ * - getDataFile dispatches to res.sendFile for LOCAL_DATA mode and
+ *   to remote fetch for staging/live S3 modes.
+ *
+ * Remote fetch paths are tested by mocking globalThis.fetch.
+ */
+
+const path = require("path");
+const getFiles = require("../getFiles");
+const globals = require("../globals");
+
+const FIXTURE_DIR = path.resolve(__dirname, "__fixtures__/server-data");
+
+const makeRes = () => ({
+  sendFile: jest.fn(),
+  send: jest.fn(),
+  set: jest.fn(),
+  status: jest.fn().mockReturnThis(),
+  headersSent: false
+});
+
+describe("getFiles (local mode)", () => {
+  beforeEach(() => {
+    globals.setGlobals({ localData: true, localDataPath: FIXTURE_DIR });
+  });
+
+  it("getDatasets serves datasets.json from the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "datasets.json"));
+  });
+
+  it("getClonalFamilies serves clones.json from the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getClonalFamilies({}, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "clones.json"));
+  });
+
+  it("getSplashImage serves the requested src under the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getSplashImage({ src: "splash.svg" }, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "splash.svg"));
+  });
+
+  it("getDatasetJson serves the requested path under the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getDatasetJson({ path: "clones.fixture-dataset-001.json" }, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "clones.fixture-dataset-001.json"));
+  });
+});
+
+describe("getFiles path validation", () => {
+  beforeEach(() => {
+    globals.setGlobals({ localData: true, localDataPath: FIXTURE_DIR });
+  });
+
+  it.each([
+    ["traversal sequence", { src: "../etc/passwd" }],
+    ["backslash", { src: "foo\\bar" }],
+    ["absolute path", { src: "/etc/passwd" }],
+    ["empty path", { src: "" }]
+  ])("getSplashImage rejects %s with 400", async (_label, query) => {
+    const res = makeRes();
+    await getFiles.getSplashImage(query, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Invalid request:/));
+    expect(res.sendFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["traversal sequence", { path: "../../secret.json" }],
+    ["absolute path", { path: "/tmp/leak.json" }],
+    ["empty path", {}]
+  ])("getDatasetJson rejects %s with 400", async (_label, query) => {
+    const res = makeRes();
+    await getFiles.getDatasetJson(query, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Invalid request:/));
+    expect(res.sendFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("getFiles (remote mode)", () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    globals.setGlobals({ localData: false });
+    originalFetch = globalThis.fetch;
+    // Each test installs its own fetch mock that returns a small payload.
+    globalThis.fetch = jest.fn(async () => ({
+      ok: true,
+      headers: { get: () => "application/json" },
+      arrayBuffer: async () => new ArrayBuffer(0)
+    }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("getDatasets fetches from the live S3 base URL by default", async () => {
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(globalThis.fetch).toHaveBeenCalledWith(`${global.REMOTE_DATA_LIVE_BASEURL}datasets.json`);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it("getDatasets honors s3=staging by fetching from the staging base URL", async () => {
+    const res = makeRes();
+    await getFiles.getDatasets({ s3: "staging" }, res);
+    expect(globalThis.fetch).toHaveBeenCalledWith(`${global.REMOTE_DATA_STAGING_BASEURL}datasets.json`);
+  });
+
+  it("propagates non-OK status codes from the remote", async () => {
+    globalThis.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      headers: { get: () => "text/html" }
+    }));
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Failed to fetch/));
+  });
+
+  it("returns 500 when the remote fetch throws", async () => {
+    globalThis.fetch = jest.fn(async () => {
+      throw new Error("network down");
+    });
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Failed to fetch/));
+  });
+});


### PR DESCRIPTION
## Summary

The `/charon/*` static-data flow (`src/server/charon.js` → `src/server/getFiles.js`) is the path the production deployment uses to serve datasets from `olmstedviz.org/data/`. Until now there was no test coverage and the dev-mode workflow for exercising it locally was undocumented (or worse: documented incorrectly — the existing note in `DEVELOPMENT.md` conflated this layout with the multi-file consolidated-upload format).

This is step 2 of the server-data sunset plan (`_ignore/server-data-sunset-plan.md`): with a local snapshot in hand from step 1, we can now codify the contract in tests and documentation.

## What's new

### Tests (24 new across 2 suites)

- **`src/server/__tests__/getFiles.test.js`** (15 tests):
  - Local-mode dispatch: `getDatasets`/`getClonalFamilies`/`getSplashImage`/`getDatasetJson` all resolve under `LOCAL_DATA_PATH`.
  - Path validation: traversal sequences, backslashes, absolute paths, and empty paths are rejected with 400 — tested through the two handlers that accept user input (`getSplashImage`, `getDatasetJson`).
  - Remote-mode dispatch with mocked `globalThis.fetch`: live vs. staging base URL, non-OK status propagation, and the fetch-throws → 500 path.
- **`src/server/__tests__/charon.test.js`** (9 tests):
  - Route dispatch maps `request=datasets`/`clonalFamilies`/`splashimage`/`json` to the correct `getFiles` handler.
  - Parsed query passthrough (`request`, `path`, `s3`).
  - Unknown and missing `request` values are silently ignored.
  - Handler throws → 500, with the `headersSent` guard preventing double-send.

### Fixture

`src/server/__tests__/__fixtures__/server-data/` — a minimal 3-file tree (1 dataset → 1 clone → 1 tree) mirroring the production layout. Used by the local-mode tests.

### Documentation

`DEVELOPMENT.md` "With Local Data (Server Mode)" section rewritten:

- Documents the actual `/data/*` file layout (`datasets.json`, `clones.{dataset_id}.json`, `tree.{tree_ident}.json`).
- Clarifies that this is **distinct from** the consolidated `.json`/`.json.gz` upload format used by the browser uploader.
- Points readers at `_ignore/snapshot-server-data.py` for producing a local mirror of the currently-deployed olmstedviz.org datasets (~780 MB).

## Test plan

- [x] `npm test` — 632 tests across 31 suites, all passing
- [x] `npx prettier --check` and `npx eslint` on touched files — clean
- [x] Manual QA: `npm run start:local _data/server-snapshot/` against the snapshot — all 3 legacy datasets load, families/trees/lineage render, requests hit `localhost:3999/data/*`.

## Out of scope

- Removing the dead `data.nextstrain.org` URL in `src/server/globals.js:6` — covered by step 5 of the plan (audit unused cruft).
- Sunsetting split-style upload — deferred to a separate follow-up PR.
- Deleting the legacy datasets from S3 — step 4 of the plan, follows after this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)