### PR TITLE
Server-side dataset updates: consolidated format support, test harness, docs, tooling (#293)

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -150,6 +150,39 @@ manifest and writes everything to `_data/server-snapshot/`
 (~780 MB, gitignored). Once it finishes you can run
 `npm run start:local _data/server-snapshot/` against it.
 
+### Deploying a server-side dataset
+
+To publish a new olmsted-cli output as a "server-side" dataset on the
+production S3 bucket, the manual flow is three steps:
+
+```bash
+# 1. Drop your consolidated olmsted-cli file into _deploy/data/.
+#    A subdirectory is fine — the manifest builder records the relative
+#    path. .json and .json.gz are both supported.
+mkdir -p _deploy/data/consolidated
+cp /path/to/my-dataset.json.gz _deploy/data/consolidated/
+
+# 2. Rebuild the manifest. Preserves any existing split-format entries;
+#    refreshes the consolidated entries based on what's on disk.
+node bin/build_datasets_manifest.js _deploy/data
+
+# 3. Upload to S3 and invalidate CloudFront. The bucket name is the
+#    same one the GitHub Actions workflow targets via vars.S3_BUCKET_NAME
+#    (typically www.olmstedviz.org).
+python3 bin/aws_deploy.py data \
+  -b <bucket> \
+  --invalidate-cloudfront
+```
+
+Datasets in `_deploy/data/` are **not** committed to the repo — test
+data files are too large. Run these steps locally with your AWS
+credentials, not from CI.
+
+The GitHub Actions "Deploy to AWS" workflow has a `data` scope option,
+but it runs against the repo's empty `_deploy/data/` after `npm run build`,
+so it is currently a no-op for data uploads. Wiring it up properly
+(e.g., pulling datasets from a separate source) is future work.
+
 ---
 
 ## Available Scripts

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,9 +98,11 @@ are supported, and a single manifest can mix them:
 | `clones.{dataset_id}.json` | Per-dataset clone list (one file per dataset)   |
 | `tree.{tree_ident}.json`   | Per-tree full payload (one file per tree ident) |
 
-**Consolidated format** (current). A manifest entry includes a
-`consolidated_path` field pointing at a single olmsted-cli output file
-(`.json` or `.json.gz`) under the data root:
+**Consolidated format** (current). Drop any olmsted-cli `.json` or
+`.json.gz` file into the data dir (or a subdirectory). The dev server
+auto-rebuilds `datasets.json` on startup — scans the dir, parses each
+consolidated file, lifts the dataset metadata, and writes a manifest
+entry with `consolidated_path` pointing at the file:
 
 ```jsonc
 [
@@ -117,6 +119,18 @@ On page load the client fetches that file and runs it through the same
 ingestion pipeline as in-browser uploads (`FileProcessor.processFile`),
 storing the result in IndexedDB. Subsequent loads short-circuit if the
 `dataset_id` is already present.
+
+Manual edits to `datasets.json` are NOT needed for consolidated files
+in dev — restart the server after dropping a file. Pre-existing
+split-format entries (entries without `consolidated_path`) are
+preserved across rebuilds.
+
+For production / deploy time, run the same scanner manually before
+uploading:
+
+```bash
+node bin/build_datasets_manifest.js _deploy/data
+```
 
 The consolidated single-file shape (`{ metadata, datasets, clones, trees }`)
 is the same as what the browser uploader accepts; this is the path for

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -87,7 +87,10 @@ Equivalent long form:
 BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData _data/server-snapshot/
 ```
 
-The directory must contain files at these paths (root-level, no nesting):
+The directory must contain a manifest at `datasets.json`. Two formats
+are supported, and a single manifest can mix them:
+
+**Split format** (legacy, auspice-shaped). One file per logical chunk:
 
 | File                       | Purpose                                         |
 | -------------------------- | ----------------------------------------------- |
@@ -95,9 +98,29 @@ The directory must contain files at these paths (root-level, no nesting):
 | `clones.{dataset_id}.json` | Per-dataset clone list (one file per dataset)   |
 | `tree.{tree_ident}.json`   | Per-tree full payload (one file per tree ident) |
 
-This is **distinct from** the consolidated single-file upload format used
-by the browser uploader (`.json` / `.json.gz` containing a single
-`{ metadata, datasets, clones, trees }` object).
+**Consolidated format** (current). A manifest entry includes a
+`consolidated_path` field pointing at a single olmsted-cli output file
+(`.json` or `.json.gz`) under the data root:
+
+```jsonc
+[
+  {
+    "ident": "...",
+    "dataset_id": "my-dataset",
+    "name": "My dataset",
+    "consolidated_path": "consolidated/my-dataset.json.gz"
+  }
+]
+```
+
+On page load the client fetches that file and runs it through the same
+ingestion pipeline as in-browser uploads (`FileProcessor.processFile`),
+storing the result in IndexedDB. Subsequent loads short-circuit if the
+`dataset_id` is already present.
+
+The consolidated single-file shape (`{ metadata, datasets, clones, trees }`)
+is the same as what the browser uploader accepts; this is the path for
+serving olmsted-cli output directly from the static bucket.
 
 ### Snapshot of the production server datasets
 
@@ -105,7 +128,7 @@ To produce a local copy of the currently-deployed olmstedviz.org datasets
 (useful for offline dev and manual QA of the server-side flow):
 
 ```bash
-python3 _ignore/snapshot-server-data.py
+python3 bin/snapshot_server_data.py
 ```
 
 The script crawls `http://www.olmstedviz.org/data/` starting from the

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -71,58 +71,81 @@ Starts the development server at `http://localhost:3999` with:
 
 ### With Local Data (Server Mode)
 
-For testing with local data files in split format:
+The dev server can serve dataset files from a local directory at `/data/*`
+instead of fetching them from a remote bucket. This is what the production
+build does for the static "server-side" datasets (currently legacy auspice
+output on olmstedviz.org).
 
 ```bash
-# Copy example data to data/ directory
-cp ../olmsted-cli/example_data/pcp/split_golden_data/* path/to/data/
-
-# Start development server with hot reloading
-./bin/olmsted-server-local.sh /path/to/data 3999 dev
-
-# OR: invoke npm scripts manually
-
-# Start with local data
-npm run start:local
-# Or specify a custom data directory:
-BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData data
+# Point start:local at a directory containing the server-side files:
+npm run start:local _data/server-snapshot/
 ```
 
-**Note**: Local data mode requires **split format** (separate files for datasets, clones, trees), not the consolidated single-file format used for browser uploads.
+Equivalent long form:
+
+```bash
+BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData _data/server-snapshot/
+```
+
+The directory must contain files at these paths (root-level, no nesting):
+
+| File                       | Purpose                                         |
+| -------------------------- | ----------------------------------------------- |
+| `datasets.json`            | Manifest — array of dataset metadata objects    |
+| `clones.{dataset_id}.json` | Per-dataset clone list (one file per dataset)   |
+| `tree.{tree_ident}.json`   | Per-tree full payload (one file per tree ident) |
+
+This is **distinct from** the consolidated single-file upload format used
+by the browser uploader (`.json` / `.json.gz` containing a single
+`{ metadata, datasets, clones, trees }` object).
+
+### Snapshot of the production server datasets
+
+To produce a local copy of the currently-deployed olmstedviz.org datasets
+(useful for offline dev and manual QA of the server-side flow):
+
+```bash
+python3 _ignore/snapshot-server-data.py
+```
+
+The script crawls `http://www.olmstedviz.org/data/` starting from the
+manifest and writes everything to `_data/server-snapshot/`
+(~780 MB, gitignored). Once it finishes you can run
+`npm run start:local _data/server-snapshot/` against it.
 
 ---
 
 ## Available Scripts
 
-| Command                 | Description                                                                                        |
-| ----------------------- | -------------------------------------------------------------------------------------------------- |
-| `npm start`             | Start development server with hot reloading                                                        |
-| `npm run start:local`   | Start with local data from `data/` directory (see [With Local Data](#with-local-data-server-mode)) |
-| `npm run build`         | Full production build — runs `build:client` + `build:server`                                       |
-| `npm run build:client`  | Build the production web bundle to `_deploy/dist/`                                                 |
-| `npm run build:server`  | Build the production Express server bundle to `server.dist.js`                                     |
-| `npm run build:electron`| Build the Electron renderer bundle to `dist/`                                                      |
-| `npm run build:start`   | Build and start production server                                                                  |
-| `npm run run:electron`  | Build the Electron bundle and launch the packaged app locally                                      |
-| `npm run dist:electron` | Package a platform-specific Electron distributable (AppImage on Linux, `.dmg` on macOS) into `_releases/` |
-| `npm run lint`          | Run ESLint on src/                                                                                 |
-| `npm run format`        | Format code with Prettier                                                                          |
-| `npm run format:check`  | Check formatting without modifying files                                                           |
-| `npm test`              | Run all Jest tests                                                                                 |
-| `npm run test:watch`    | Run tests in watch mode (re-runs on file changes)                                                  |
-| `npm run test:coverage` | Run tests with coverage report                                                                     |
-| `npm run clean`         | Remove build artifacts                                                                             |
+| Command                  | Description                                                                                               |
+| ------------------------ | --------------------------------------------------------------------------------------------------------- |
+| `npm start`              | Start development server with hot reloading                                                               |
+| `npm run start:local`    | Start with local data from `data/` directory (see [With Local Data](#with-local-data-server-mode))        |
+| `npm run build`          | Full production build — runs `build:client` + `build:server`                                              |
+| `npm run build:client`   | Build the production web bundle to `_deploy/dist/`                                                        |
+| `npm run build:server`   | Build the production Express server bundle to `server.dist.js`                                            |
+| `npm run build:electron` | Build the Electron renderer bundle to `dist/`                                                             |
+| `npm run build:start`    | Build and start production server                                                                         |
+| `npm run run:electron`   | Build the Electron bundle and launch the packaged app locally                                             |
+| `npm run dist:electron`  | Package a platform-specific Electron distributable (AppImage on Linux, `.dmg` on macOS) into `_releases/` |
+| `npm run lint`           | Run ESLint on src/                                                                                        |
+| `npm run format`         | Format code with Prettier                                                                                 |
+| `npm run format:check`   | Check formatting without modifying files                                                                  |
+| `npm test`               | Run all Jest tests                                                                                        |
+| `npm run test:watch`     | Run tests in watch mode (re-runs on file changes)                                                         |
+| `npm run test:coverage`  | Run tests with coverage report                                                                            |
+| `npm run clean`          | Remove build artifacts                                                                                    |
 
 ### Build Pipeline
 
 Olmsted has two distribution channels that share the same React source but use different webpack configs. Both go through Babel for JSX/ESNext transpilation.
 
-| Config                        | Used by                     | Output                          | Purpose                            |
-| ----------------------------- | --------------------------- | ------------------------------- | ---------------------------------- |
-| `webpack.config.dev.js`       | `npm start`                 | `_devel/` (in-memory via HMR)   | Hot-reloading dev server           |
-| `webpack.config.prod.js`      | `npm run build:client`      | `_deploy/dist/bundle.js`        | Production web bundle (S3/Docker)  |
-| `webpack.config.server.js`    | `npm run build:server`      | `server.dist.js`                | Bundled Express server             |
-| `webpack.config.electron.js`  | `npm run build:electron`    | `dist/bundle.js`                | Renderer for the Electron app      |
+| Config                       | Used by                  | Output                        | Purpose                           |
+| ---------------------------- | ------------------------ | ----------------------------- | --------------------------------- |
+| `webpack.config.dev.js`      | `npm start`              | `_devel/` (in-memory via HMR) | Hot-reloading dev server          |
+| `webpack.config.prod.js`     | `npm run build:client`   | `_deploy/dist/bundle.js`      | Production web bundle (S3/Docker) |
+| `webpack.config.server.js`   | `npm run build:server`   | `server.dist.js`              | Bundled Express server            |
+| `webpack.config.electron.js` | `npm run build:electron` | `dist/bundle.js`              | Renderer for the Electron app     |
 
 ```bash
 # Full production build (web)
@@ -279,13 +302,13 @@ Import shared mock data from `src/__test-data__/mockState.js` rather than duplic
 
 ### Configuration
 
-| File                    | Purpose                                                                                                                                   |
-| ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
-| `jest.config.js`        | Jest config: jsdom env, babel-jest transform, CSS/image mocks, ESM package handling, `setupFilesAfterEnv` for `@testing-library/jest-dom` |
-| `jest.setup.js`         | `fake-indexeddb/auto` polyfill, `structuredClone` polyfill for Node 18, sessionStorage fallback, console noise suppression                |
-| `__mocks__/fileMock.js` | Stub for image/file imports                                                                                                               |
-| `.babelrc` `"test"` env | Avoids loading react-refresh plugin (crashes in Jest)                                                                                     |
-| `eslint.config.mjs` test override | Adds Jest globals for `__tests__/` files so ESLint recognizes `describe`, `it`, `expect`, etc.                                  |
+| File                              | Purpose                                                                                                                                   |
+| --------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------- |
+| `jest.config.js`                  | Jest config: jsdom env, babel-jest transform, CSS/image mocks, ESM package handling, `setupFilesAfterEnv` for `@testing-library/jest-dom` |
+| `jest.setup.js`                   | `fake-indexeddb/auto` polyfill, `structuredClone` polyfill for Node 18, sessionStorage fallback, console noise suppression                |
+| `__mocks__/fileMock.js`           | Stub for image/file imports                                                                                                               |
+| `.babelrc` `"test"` env           | Avoids loading react-refresh plugin (crashes in Jest)                                                                                     |
+| `eslint.config.mjs` test override | Adds Jest globals for `__tests__/` files so ESLint recognizes `describe`, `it`, `expect`, etc.                                            |
 
 **Key dependencies:**
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -77,14 +77,14 @@ build does for the static "server-side" datasets (currently legacy auspice
 output on olmstedviz.org).
 
 ```bash
-# Point start:local at a directory containing the server-side files:
-npm run start:local _data/server-snapshot/
+# Point start:local at any directory containing the server-side files:
+npm run start:local <path-to-data-dir>
 ```
 
 Equivalent long form:
 
 ```bash
-BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData _data/server-snapshot/
+BABEL_ENV=dev ./node_modules/.bin/babel-node server.js dev localData <path-to-data-dir>
 ```
 
 The directory must contain a manifest at `datasets.json`. Two formats
@@ -136,19 +136,37 @@ The consolidated single-file shape (`{ metadata, datasets, clones, trees }`)
 is the same as what the browser uploader accepts; this is the path for
 serving olmsted-cli output directly from the static bucket.
 
-### Snapshot of the production server datasets
+### Snapshotting production data
 
-To produce a local copy of the currently-deployed olmstedviz.org datasets
-(useful for offline dev and manual QA of the server-side flow):
+Two complementary mechanisms are available, both reading from the live
+S3 bucket via HTTP (no credentials needed for the public bucket):
+
+**Manifest-driven snapshot** — `bin/snapshot_server_data.py` reads
+`datasets.json` and follows its references (per-dataset clones files,
+per-tree files). Use it to produce a snapshot that's structured
+identically to what `npm run start:local` expects, so the result can
+be served back unchanged for offline dev and manual QA of the
+server-side flow:
 
 ```bash
-python3 bin/snapshot_server_data.py
+python3 bin/snapshot_server_data.py [-u <base-url>] [-o <output-dir>]
 ```
 
-The script crawls `http://www.olmstedviz.org/data/` starting from the
-manifest and writes everything to `_data/server-snapshot/`
-(~780 MB, gitignored). Once it finishes you can run
-`npm run start:local _data/server-snapshot/` against it.
+Defaults to the production olmstedviz.org base URL; override `-u` to
+snapshot a staging bucket. Pass `--help` for full options.
+
+**Full bucket dump** — `bin/aws_download.py` walks the bucket and
+fetches every object, ignoring the manifest. Use it as a complete
+safety-net before destructive operations:
+
+```bash
+python3 bin/aws_download.py -b <bucket> -o <output-dir> [--anonymous]
+```
+
+The manifest snapshot is the right tool if you intend to serve the
+data back via `start:local`; the bucket dump is the right tool if you
+want a verbatim before-state to compare against `_deploy/` and
+identify orphans.
 
 ### Deploying a server-side dataset
 

--- a/bin/__tests__/build_datasets_manifest.test.js
+++ b/bin/__tests__/build_datasets_manifest.test.js
@@ -91,15 +91,16 @@ describe("isConsolidatedShape", () => {
 describe("scanForConsolidatedDatasets", () => {
   it("finds a top-level consolidated .json file", () => {
     write("foo.json", makeConsolidatedPayload({ dataset_id: "ds-foo" }));
-    const entries = scanForConsolidatedDatasets(tmpDir);
+    const { entries, skipped } = scanForConsolidatedDatasets(tmpDir);
     expect(entries).toHaveLength(1);
     expect(entries[0].dataset_id).toBe("ds-foo");
     expect(entries[0].consolidated_path).toBe("foo.json");
+    expect(skipped).toBe(0);
   });
 
   it("finds a .json.gz file and decompresses it", () => {
     writeGz("bar.json.gz", makeConsolidatedPayload({ dataset_id: "ds-bar" }));
-    const entries = scanForConsolidatedDatasets(tmpDir);
+    const { entries } = scanForConsolidatedDatasets(tmpDir);
     expect(entries).toHaveLength(1);
     expect(entries[0].dataset_id).toBe("ds-bar");
     expect(entries[0].consolidated_path).toBe("bar.json.gz");
@@ -107,32 +108,46 @@ describe("scanForConsolidatedDatasets", () => {
 
   it("descends into subdirectories", () => {
     write("consolidated/nested.json", makeConsolidatedPayload({ dataset_id: "ds-nested" }));
-    const entries = scanForConsolidatedDatasets(tmpDir);
+    const { entries } = scanForConsolidatedDatasets(tmpDir);
     expect(entries).toHaveLength(1);
     expect(entries[0].consolidated_path).toBe("consolidated/nested.json");
   });
 
-  it("skips datasets.json, clones.*.json, tree.*.json", () => {
+  it("skips datasets.json, clones.*.json, tree.*.json without counting them as skipped", () => {
     write("datasets.json", []);
     write("clones.ds-x.json", []);
     write("tree.abc-123.json", { nodes: [] });
-    const entries = scanForConsolidatedDatasets(tmpDir);
+    const { entries, skipped } = scanForConsolidatedDatasets(tmpDir);
     expect(entries).toEqual([]);
+    // These are not "candidate" files; they're filtered before parsing.
+    expect(skipped).toBe(0);
   });
 
-  it("skips files that don't match the consolidated shape", () => {
+  it("counts files that don't match the consolidated shape as skipped", () => {
     write("not-consolidated.json", { just: "a random object" });
-    const entries = scanForConsolidatedDatasets(tmpDir);
+    const { entries, skipped } = scanForConsolidatedDatasets(tmpDir);
     expect(entries).toEqual([]);
+    expect(skipped).toBe(1);
   });
 
-  it("skips files that fail to parse but doesn't throw", () => {
+  it("counts malformed-JSON files as skipped and warns instead of throwing", () => {
     write("malformed.json", "not valid json");
     const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
-    const entries = scanForConsolidatedDatasets(tmpDir);
+    const { entries, skipped } = scanForConsolidatedDatasets(tmpDir);
     expect(entries).toEqual([]);
+    expect(skipped).toBe(1);
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("malformed.json"));
     consoleSpy.mockRestore();
+  });
+
+  it("does not follow symlinked directories (avoids cycles)", () => {
+    // Real consolidated file inside a real subdir
+    write("real/inside.json", makeConsolidatedPayload({ dataset_id: "ds-real" }));
+    // A symlink at the root that points back at the root — would loop forever
+    // if scan followed it.
+    fs.symlinkSync(tmpDir, path.join(tmpDir, "loop"));
+    const { entries } = scanForConsolidatedDatasets(tmpDir);
+    expect(entries.map((e) => e.dataset_id)).toEqual(["ds-real"]);
   });
 });
 

--- a/bin/__tests__/build_datasets_manifest.test.js
+++ b/bin/__tests__/build_datasets_manifest.test.js
@@ -1,0 +1,201 @@
+/**
+ * Tests for bin/build_datasets_manifest.js
+ *
+ * Each test uses a fresh temp directory so we can write and re-read
+ * the manifest without polluting checked-in fixtures.
+ */
+
+const fs = require("fs");
+const os = require("os");
+const path = require("path");
+const zlib = require("zlib");
+const {
+  buildManifest,
+  scanForConsolidatedDatasets,
+  loadExistingSplitEntries,
+  isCandidateConsolidatedFile,
+  isConsolidatedShape
+} = require("../build_datasets_manifest");
+
+const makeConsolidatedPayload = (overrides = {}) => ({
+  metadata: { schema_version: "2.0.0", ...overrides.metadata },
+  datasets: [
+    {
+      ident: overrides.ident || "ident-xyz",
+      dataset_id: overrides.dataset_id || "ds-xyz",
+      name: overrides.name || "Dataset XYZ",
+      clone_count: overrides.clone_count ?? 1,
+      schema_version: "2.0.0"
+    }
+  ],
+  clones: { "ds-xyz": [] },
+  trees: []
+});
+
+let tmpDir;
+
+beforeEach(() => {
+  tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "manifest-test-"));
+});
+
+afterEach(() => {
+  fs.rmSync(tmpDir, { recursive: true, force: true });
+});
+
+const write = (relPath, content) => {
+  const full = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  if (typeof content === "string") {
+    fs.writeFileSync(full, content);
+  } else {
+    fs.writeFileSync(full, JSON.stringify(content));
+  }
+  return full;
+};
+
+const writeGz = (relPath, payload) => {
+  const full = path.join(tmpDir, relPath);
+  fs.mkdirSync(path.dirname(full), { recursive: true });
+  fs.writeFileSync(full, zlib.gzipSync(JSON.stringify(payload)));
+  return full;
+};
+
+describe("isCandidateConsolidatedFile", () => {
+  it.each([
+    ["consolidated.json", true],
+    ["something.json.gz", true],
+    ["datasets.json", false],
+    ["clones.foo.json", false],
+    ["tree.abc.json", false],
+    ["readme.md", false]
+  ])("isCandidateConsolidatedFile(%p) === %p", (name, expected) => {
+    expect(isCandidateConsolidatedFile(name)).toBe(expected);
+  });
+});
+
+describe("isConsolidatedShape", () => {
+  it("accepts a well-formed payload", () => {
+    expect(isConsolidatedShape(makeConsolidatedPayload())).toBe(true);
+  });
+
+  it.each([
+    [null],
+    [{}],
+    [{ metadata: {}, datasets: [], clones: {}, trees: [] }], // empty datasets
+    [{ datasets: [{ dataset_id: "x" }], clones: {}, trees: [] }] // no metadata
+  ])("rejects malformed payload %p", (payload) => {
+    expect(isConsolidatedShape(payload)).toBe(false);
+  });
+});
+
+describe("scanForConsolidatedDatasets", () => {
+  it("finds a top-level consolidated .json file", () => {
+    write("foo.json", makeConsolidatedPayload({ dataset_id: "ds-foo" }));
+    const entries = scanForConsolidatedDatasets(tmpDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].dataset_id).toBe("ds-foo");
+    expect(entries[0].consolidated_path).toBe("foo.json");
+  });
+
+  it("finds a .json.gz file and decompresses it", () => {
+    writeGz("bar.json.gz", makeConsolidatedPayload({ dataset_id: "ds-bar" }));
+    const entries = scanForConsolidatedDatasets(tmpDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].dataset_id).toBe("ds-bar");
+    expect(entries[0].consolidated_path).toBe("bar.json.gz");
+  });
+
+  it("descends into subdirectories", () => {
+    write("consolidated/nested.json", makeConsolidatedPayload({ dataset_id: "ds-nested" }));
+    const entries = scanForConsolidatedDatasets(tmpDir);
+    expect(entries).toHaveLength(1);
+    expect(entries[0].consolidated_path).toBe("consolidated/nested.json");
+  });
+
+  it("skips datasets.json, clones.*.json, tree.*.json", () => {
+    write("datasets.json", []);
+    write("clones.ds-x.json", []);
+    write("tree.abc-123.json", { nodes: [] });
+    const entries = scanForConsolidatedDatasets(tmpDir);
+    expect(entries).toEqual([]);
+  });
+
+  it("skips files that don't match the consolidated shape", () => {
+    write("not-consolidated.json", { just: "a random object" });
+    const entries = scanForConsolidatedDatasets(tmpDir);
+    expect(entries).toEqual([]);
+  });
+
+  it("skips files that fail to parse but doesn't throw", () => {
+    write("malformed.json", "not valid json");
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+    const entries = scanForConsolidatedDatasets(tmpDir);
+    expect(entries).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining("malformed.json"));
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("loadExistingSplitEntries", () => {
+  it("returns [] when manifest doesn't exist", () => {
+    expect(loadExistingSplitEntries(path.join(tmpDir, "datasets.json"))).toEqual([]);
+  });
+
+  it("returns split entries (no consolidated_path) and drops consolidated ones", () => {
+    write("datasets.json", [
+      { dataset_id: "split-1", name: "Split One" },
+      { dataset_id: "consolidated-1", consolidated_path: "consolidated-1.json" }
+    ]);
+    const split = loadExistingSplitEntries(path.join(tmpDir, "datasets.json"));
+    expect(split).toHaveLength(1);
+    expect(split[0].dataset_id).toBe("split-1");
+  });
+
+  it("returns [] and warns when the existing manifest is malformed", () => {
+    write("datasets.json", "not a valid manifest");
+    const consoleSpy = jest.spyOn(console, "warn").mockImplementation();
+    expect(loadExistingSplitEntries(path.join(tmpDir, "datasets.json"))).toEqual([]);
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});
+
+describe("buildManifest (integration)", () => {
+  it("preserves legacy split entries and refreshes consolidated entries", () => {
+    // Existing manifest with a hand-curated split entry AND a stale
+    // consolidated entry pointing at a file that no longer exists.
+    write("datasets.json", [
+      { dataset_id: "legacy-split", name: "Legacy split dataset" },
+      { dataset_id: "stale-consolidated", consolidated_path: "ghost.json" }
+    ]);
+    // The actual consolidated file on disk:
+    write("real.json", makeConsolidatedPayload({ dataset_id: "real-consolidated" }));
+
+    const result = buildManifest(tmpDir);
+
+    expect(result.split).toHaveLength(1);
+    expect(result.split[0].dataset_id).toBe("legacy-split");
+    expect(result.consolidated).toHaveLength(1);
+    expect(result.consolidated[0].dataset_id).toBe("real-consolidated");
+
+    // The on-disk manifest reflects the merge.
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmpDir, "datasets.json"), "utf-8"));
+    expect(onDisk).toHaveLength(2);
+    const idents = onDisk.map((e) => e.dataset_id).sort();
+    expect(idents).toEqual(["legacy-split", "real-consolidated"]);
+  });
+
+  it("writes a fresh manifest when none exists", () => {
+    write("foo.json", makeConsolidatedPayload({ dataset_id: "foo" }));
+    buildManifest(tmpDir);
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmpDir, "datasets.json"), "utf-8"));
+    expect(onDisk).toHaveLength(1);
+    expect(onDisk[0].consolidated_path).toBe("foo.json");
+  });
+
+  it("writes an empty manifest when the dir is empty", () => {
+    buildManifest(tmpDir);
+    const onDisk = JSON.parse(fs.readFileSync(path.join(tmpDir, "datasets.json"), "utf-8"));
+    expect(onDisk).toEqual([]);
+  });
+});

--- a/bin/aws_delete.py
+++ b/bin/aws_delete.py
@@ -1,0 +1,209 @@
+#!/usr/bin/env python3
+"""
+Delete files from an S3 bucket with optional prefix and search filtering.
+
+Mirrors aws_download.py conventions:
+- -b/--bucket, -p/--prefix, -s/--search, -r/--regex, -c/--creds
+- Anonymous-access support for public buckets
+- --list-only to preview without deleting
+
+Safety:
+- --dry-run is the DEFAULT. Pass --confirm to actually delete.
+- Always prints the file count + total size and (when there are many
+  files) shows the first 10 and last 5 keys for sanity-checking before
+  deletion happens.
+
+Examples:
+  # Preview what would be deleted under prefix data/ (dry-run, default)
+  %(prog)s -b www.olmstedviz.org -p data/
+
+  # Actually delete (after reviewing the dry-run output)
+  %(prog)s -b www.olmstedviz.org -p data/ --confirm
+"""
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+import boto3
+import yaml
+
+
+def load_credentials(creds_filename):
+    """Load AWS credentials from YAML file."""
+    with open(creds_filename) as handle:
+        return yaml.load(handle, Loader=yaml.SafeLoader)
+
+
+def create_s3_client(credentials=None):
+    """Create S3 client with or without credentials."""
+    if credentials:
+        return boto3.client("s3", **credentials)
+    from botocore import UNSIGNED
+    from botocore.config import Config
+
+    return boto3.client("s3", config=Config(signature_version=UNSIGNED))
+
+
+def format_file_size(size):
+    """Format file size in human-readable form."""
+    for unit in ["B", "KB", "MB", "GB", "TB"]:
+        if size < 1024.0:
+            return f"{size:.2f} {unit}"
+        size /= 1024.0
+    return f"{size:.2f} PB"
+
+
+def list_objects(client, bucket_name, prefix="", search_term=None, use_regex=False):
+    """List objects in `bucket_name` under `prefix`, optionally filtered.
+
+    Returns a list of {Key, Size} dicts.
+    """
+    pattern = None
+    if search_term and use_regex:
+        try:
+            pattern = re.compile(search_term, re.IGNORECASE)
+        except re.error as e:
+            print(f"Invalid regex pattern: {e}", file=sys.stderr)
+            sys.exit(2)
+
+    paginator = client.get_paginator("list_objects_v2")
+    matched = []
+    skipped = 0
+    for page in paginator.paginate(Bucket=bucket_name, Prefix=prefix):
+        for obj in page.get("Contents", []):
+            key = obj["Key"]
+            if key.endswith("/"):
+                continue
+            if search_term:
+                if use_regex:
+                    if not pattern.search(key):
+                        skipped += 1
+                        continue
+                elif search_term.lower() not in key.lower():
+                    skipped += 1
+                    continue
+            matched.append(obj)
+    return matched, skipped
+
+
+def print_summary(matched, search_term, skipped):
+    """Print a count + size summary, plus head/tail key samples."""
+    total_size = sum(obj["Size"] for obj in matched)
+    if search_term:
+        print(f"Matched {len(matched)} files (skipped {skipped} non-matching)")
+    else:
+        print(f"Found {len(matched)} files")
+    print(f"Total size: {format_file_size(total_size)}\n")
+
+    if not matched:
+        return
+
+    head = 10
+    tail = 5
+    if len(matched) <= head + tail:
+        for obj in matched:
+            print(f"  {obj['Key']} ({format_file_size(obj['Size'])})")
+    else:
+        for obj in matched[:head]:
+            print(f"  {obj['Key']} ({format_file_size(obj['Size'])})")
+        print(f"  … {len(matched) - head - tail} more …")
+        for obj in matched[-tail:]:
+            print(f"  {obj['Key']} ({format_file_size(obj['Size'])})")
+    print()
+
+
+def delete_batch(client, bucket_name, keys):
+    """Delete up to 1000 keys in a single DeleteObjects call."""
+    response = client.delete_objects(
+        Bucket=bucket_name,
+        Delete={"Objects": [{"Key": k} for k in keys], "Quiet": False},
+    )
+    deleted = len(response.get("Deleted", []))
+    errors = response.get("Errors", [])
+    return deleted, errors
+
+
+def delete_objects(client, bucket_name, matched):
+    """Delete matched objects in chunks of 1000 (the S3 batch limit)."""
+    BATCH = 1000
+    total_deleted = 0
+    all_errors = []
+    keys = [obj["Key"] for obj in matched]
+    for i in range(0, len(keys), BATCH):
+        batch = keys[i : i + BATCH]
+        deleted, errors = delete_batch(client, bucket_name, batch)
+        total_deleted += deleted
+        all_errors.extend(errors)
+        print(f"  [{min(i + BATCH, len(keys))}/{len(keys)}] {total_deleted} deleted, {len(all_errors)} errors")
+    return total_deleted, all_errors
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("-b", "--bucket", required=True, help="S3 bucket name")
+    parser.add_argument("-p", "--prefix", default="", help="Only consider keys with this prefix")
+    parser.add_argument("-s", "--search", help="Filter keys by substring (case-insensitive)")
+    parser.add_argument("-r", "--regex", action="store_true", help="Treat --search as a regex")
+    parser.add_argument("-c", "--creds", help="Path to AWS credentials YAML file")
+    parser.add_argument("--anonymous", action="store_true", help="Access public bucket without credentials")
+    parser.add_argument("--list-only", action="store_true", help="Only list matching files; do not delete")
+    parser.add_argument(
+        "--confirm",
+        action="store_true",
+        help="Actually delete. WITHOUT THIS FLAG, this script only previews (dry-run is the default).",
+    )
+
+    args = parser.parse_args()
+
+    if args.creds:
+        print(f"Loading credentials from: {args.creds}")
+        client = create_s3_client(load_credentials(args.creds))
+    elif args.anonymous:
+        print("Using anonymous access (public bucket)")
+        client = create_s3_client()
+    else:
+        print("Using default AWS credentials")
+        client = boto3.client("s3")
+
+    print(f"\nBucket: {args.bucket}")
+    if args.prefix:
+        print(f"Prefix: '{args.prefix}'")
+    if args.search:
+        kind = "regex" if args.regex else "substring"
+        print(f"Filter ({kind}): '{args.search}'")
+
+    matched, skipped = list_objects(client, args.bucket, args.prefix, args.search, args.regex)
+    print()
+    print_summary(matched, args.search, skipped)
+
+    if args.list_only:
+        print("(--list-only — exiting without deleting)")
+        return
+
+    if not args.confirm:
+        print("DRY RUN — pass --confirm to actually delete these files.")
+        return
+
+    if not matched:
+        print("Nothing to delete.")
+        return
+
+    print(f"=== Deleting {len(matched)} files from {args.bucket} ===")
+    deleted, errors = delete_objects(client, args.bucket, matched)
+    print(f"\nDeleted: {deleted}")
+    if errors:
+        print(f"\nErrors ({len(errors)}):")
+        for err in errors[:10]:
+            print(f"  {err.get('Key')}: {err.get('Message')}")
+        if len(errors) > 10:
+            print(f"  … and {len(errors) - 10} more")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/build_datasets_manifest.js
+++ b/bin/build_datasets_manifest.js
@@ -1,0 +1,150 @@
+#!/usr/bin/env node
+/* eslint no-console: off */
+/**
+ * Build a `datasets.json` manifest from the consolidated dataset files
+ * present in a data directory.
+ *
+ * Walks the directory recursively, parses each consolidated olmsted-cli
+ * file (`.json` or `.json.gz`, anything that isn't `datasets.json`,
+ * `clones.*.json`, or `tree.*.json`), lifts the dataset metadata from
+ * `data.datasets[0]`, and writes a fresh `datasets.json` with a
+ * `consolidated_path` field pointing at each file.
+ *
+ * Pre-existing manifest entries WITHOUT a `consolidated_path` (i.e.
+ * legacy split-format entries) are preserved. Pre-existing
+ * consolidated entries are replaced by the fresh scan.
+ *
+ * Triggered automatically on `npm run start:local` (see server.js).
+ * Can also be invoked directly:
+ *
+ *   node bin/build_datasets_manifest.js _data/server-snapshot/
+ */
+
+const fs = require("fs");
+const path = require("path");
+const zlib = require("zlib");
+
+const MANIFEST_FILENAME = "datasets.json";
+
+/**
+ * Files that are NOT consolidated datasets and should be skipped.
+ * Returns true if the filename looks like a consolidated dataset file.
+ */
+function isCandidateConsolidatedFile(name) {
+  if (name === MANIFEST_FILENAME) return false;
+  if (name.startsWith("clones.")) return false;
+  if (name.startsWith("tree.")) return false;
+  return name.endsWith(".json") || name.endsWith(".json.gz");
+}
+
+function readConsolidatedFile(filepath) {
+  const buffer = fs.readFileSync(filepath);
+  const text = filepath.endsWith(".gz") ? zlib.gunzipSync(buffer).toString("utf-8") : buffer.toString("utf-8");
+  return JSON.parse(text);
+}
+
+function isConsolidatedShape(data) {
+  return Boolean(
+    data &&
+    typeof data === "object" &&
+    data.metadata &&
+    Array.isArray(data.datasets) &&
+    data.datasets.length > 0 &&
+    data.clones &&
+    Array.isArray(data.trees)
+  );
+}
+
+/**
+ * Walk `rootDir` and return manifest entries for each consolidated
+ * dataset file found. Files that fail to parse or don't match the
+ * consolidated shape are skipped with a warning.
+ *
+ * @param {string} rootDir - absolute path to the data dir
+ * @returns {Array<Object>} manifest entries with consolidated_path set
+ */
+function scanForConsolidatedDatasets(rootDir) {
+  const entries = [];
+
+  function walk(dir, relPath) {
+    for (const name of fs.readdirSync(dir)) {
+      const full = path.join(dir, name);
+      const rel = relPath ? path.posix.join(relPath, name) : name;
+      const stat = fs.statSync(full);
+      if (stat.isDirectory()) {
+        walk(full, rel);
+        continue;
+      }
+      if (!isCandidateConsolidatedFile(name)) continue;
+      try {
+        const data = readConsolidatedFile(full);
+        if (!isConsolidatedShape(data)) continue;
+        const ds = data.datasets[0];
+        entries.push({ ...ds, consolidated_path: rel });
+      } catch (err) {
+        console.warn(`build_datasets_manifest: skipping ${rel}: ${err.message}`);
+      }
+    }
+  }
+
+  walk(rootDir, "");
+  return entries;
+}
+
+/**
+ * Read the existing manifest (if any) and return its split-format
+ * entries (entries without a consolidated_path). Returns [] when the
+ * manifest is missing or malformed.
+ */
+function loadExistingSplitEntries(manifestPath) {
+  if (!fs.existsSync(manifestPath)) return [];
+  try {
+    const data = JSON.parse(fs.readFileSync(manifestPath, "utf-8"));
+    if (!Array.isArray(data)) return [];
+    return data.filter((entry) => entry && !entry.consolidated_path);
+  } catch (err) {
+    console.warn(`build_datasets_manifest: existing manifest is invalid, starting fresh (${err.message})`);
+    return [];
+  }
+}
+
+/**
+ * Rebuild `datasets.json` in `dataDir`. Idempotent and non-destructive
+ * for split-format entries.
+ *
+ * @param {string} dataDir
+ * @returns {{ split: Array, consolidated: Array }} the two slices that
+ *   ended up in the manifest
+ */
+function buildManifest(dataDir) {
+  const manifestPath = path.join(dataDir, MANIFEST_FILENAME);
+  const splitEntries = loadExistingSplitEntries(manifestPath);
+  const consolidatedEntries = scanForConsolidatedDatasets(dataDir);
+  const merged = [...splitEntries, ...consolidatedEntries];
+  fs.writeFileSync(manifestPath, JSON.stringify(merged, null, 2) + "\n");
+  return { split: splitEntries, consolidated: consolidatedEntries };
+}
+
+module.exports = {
+  buildManifest,
+  scanForConsolidatedDatasets,
+  loadExistingSplitEntries,
+  isCandidateConsolidatedFile,
+  isConsolidatedShape
+};
+
+if (require.main === module) {
+  const dataDir = process.argv[2];
+  if (!dataDir) {
+    console.error("Usage: build_datasets_manifest.js <data-dir>");
+    process.exit(1);
+  }
+  if (!fs.existsSync(dataDir) || !fs.statSync(dataDir).isDirectory()) {
+    console.error(`Not a directory: ${dataDir}`);
+    process.exit(1);
+  }
+  const result = buildManifest(dataDir);
+  console.log(
+    `build_datasets_manifest: wrote ${result.split.length} split + ${result.consolidated.length} consolidated entries to ${path.join(dataDir, MANIFEST_FILENAME)}`
+  );
+}

--- a/bin/build_datasets_manifest.js
+++ b/bin/build_datasets_manifest.js
@@ -29,6 +29,13 @@ const MANIFEST_FILENAME = "datasets.json";
 /**
  * Files that are NOT consolidated datasets and should be skipped.
  * Returns true if the filename looks like a consolidated dataset file.
+ *
+ * The `clones.*` / `tree.*` prefix exclusion is an *optimization* — it
+ * lets us avoid parsing the per-clone/per-tree files in a legacy split
+ * snapshot. Correctness is enforced by `isConsolidatedShape` after the
+ * parse, so a renamed-to-look-split file would still be rejected, and
+ * a renamed-to-look-consolidated file with the right shape would still
+ * be accepted.
  */
 function isCandidateConsolidatedFile(name) {
   if (name === MANIFEST_FILENAME) return false;
@@ -58,37 +65,49 @@ function isConsolidatedShape(data) {
 /**
  * Walk `rootDir` and return manifest entries for each consolidated
  * dataset file found. Files that fail to parse or don't match the
- * consolidated shape are skipped with a warning.
+ * consolidated shape are skipped with a warning; the count of skipped
+ * files is returned alongside the entries so the caller can surface it
+ * in startup logs.
+ *
+ * Symlinks (file or directory) are deliberately not followed —
+ * `withFileTypes: true` causes Dirent.isDirectory() to return false for
+ * symlinks, so a cyclic or runaway symlink can't trap the scan.
  *
  * @param {string} rootDir - absolute path to the data dir
- * @returns {Array<Object>} manifest entries with consolidated_path set
+ * @returns {{ entries: Array<Object>, skipped: number }}
  */
 function scanForConsolidatedDatasets(rootDir) {
   const entries = [];
+  let skipped = 0;
 
   function walk(dir, relPath) {
-    for (const name of fs.readdirSync(dir)) {
+    for (const dirent of fs.readdirSync(dir, { withFileTypes: true })) {
+      const name = dirent.name;
       const full = path.join(dir, name);
       const rel = relPath ? path.posix.join(relPath, name) : name;
-      const stat = fs.statSync(full);
-      if (stat.isDirectory()) {
+      if (dirent.isDirectory()) {
         walk(full, rel);
         continue;
       }
+      if (!dirent.isFile()) continue; // skip symlinks, devices, etc.
       if (!isCandidateConsolidatedFile(name)) continue;
       try {
         const data = readConsolidatedFile(full);
-        if (!isConsolidatedShape(data)) continue;
+        if (!isConsolidatedShape(data)) {
+          skipped += 1;
+          continue;
+        }
         const ds = data.datasets[0];
         entries.push({ ...ds, consolidated_path: rel });
       } catch (err) {
+        skipped += 1;
         console.warn(`build_datasets_manifest: skipping ${rel}: ${err.message}`);
       }
     }
   }
 
   walk(rootDir, "");
-  return entries;
+  return { entries, skipped };
 }
 
 /**
@@ -113,16 +132,17 @@ function loadExistingSplitEntries(manifestPath) {
  * for split-format entries.
  *
  * @param {string} dataDir
- * @returns {{ split: Array, consolidated: Array }} the two slices that
- *   ended up in the manifest
+ * @returns {{ split: Array, consolidated: Array, skipped: number }}
+ *   the two slices written to the manifest, plus a count of files that
+ *   looked consolidated but failed to parse or didn't match the shape
  */
 function buildManifest(dataDir) {
   const manifestPath = path.join(dataDir, MANIFEST_FILENAME);
   const splitEntries = loadExistingSplitEntries(manifestPath);
-  const consolidatedEntries = scanForConsolidatedDatasets(dataDir);
+  const { entries: consolidatedEntries, skipped } = scanForConsolidatedDatasets(dataDir);
   const merged = [...splitEntries, ...consolidatedEntries];
   fs.writeFileSync(manifestPath, JSON.stringify(merged, null, 2) + "\n");
-  return { split: splitEntries, consolidated: consolidatedEntries };
+  return { split: splitEntries, consolidated: consolidatedEntries, skipped };
 }
 
 module.exports = {
@@ -144,7 +164,8 @@ if (require.main === module) {
     process.exit(1);
   }
   const result = buildManifest(dataDir);
+  const skippedSuffix = result.skipped > 0 ? ` (${result.skipped} file(s) skipped — see warnings above)` : "";
   console.log(
-    `build_datasets_manifest: wrote ${result.split.length} split + ${result.consolidated.length} consolidated entries to ${path.join(dataDir, MANIFEST_FILENAME)}`
+    `build_datasets_manifest: wrote ${result.split.length} split + ${result.consolidated.length} consolidated entries to ${path.join(dataDir, MANIFEST_FILENAME)}${skippedSuffix}`
   );
 }

--- a/bin/snapshot_server_data.py
+++ b/bin/snapshot_server_data.py
@@ -1,0 +1,111 @@
+#!/usr/bin/env python3
+"""
+One-shot snapshot of the legacy olmstedviz.org datasets.
+
+Crawls http://www.olmstedviz.org/data/, starting from the manifest, and
+saves a local copy under _data/server-snapshot/ preserving the URL layout.
+"""
+
+import json
+import os
+import sys
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from pathlib import Path
+from urllib.request import urlopen
+from urllib.error import HTTPError, URLError
+
+BASE_URL = "http://www.olmstedviz.org/data"
+OUT_DIR = Path(__file__).resolve().parent.parent / "_data" / "server-snapshot"
+PARALLELISM = 16
+TIMEOUT = 30
+
+
+def fetch(path: str) -> bytes:
+    url = f"{BASE_URL}/{path}"
+    with urlopen(url, timeout=TIMEOUT) as resp:
+        return resp.read()
+
+
+def save(path: str, data: bytes) -> int:
+    out = OUT_DIR / path
+    out.parent.mkdir(parents=True, exist_ok=True)
+    out.write_bytes(data)
+    return len(data)
+
+
+def fetch_and_save(path: str) -> tuple[str, int, str | None]:
+    try:
+        data = fetch(path)
+        size = save(path, data)
+        return path, size, None
+    except (HTTPError, URLError, TimeoutError) as e:
+        return path, 0, str(e)
+
+
+def main():
+    print(f"Snapshot target: {OUT_DIR}")
+    OUT_DIR.mkdir(parents=True, exist_ok=True)
+
+    print("\n[1/3] Fetching manifest…")
+    manifest_bytes = fetch("datasets.json")
+    save("datasets.json", manifest_bytes)
+    manifest = json.loads(manifest_bytes)
+    print(f"  → datasets.json ({len(manifest_bytes):,} bytes, {len(manifest)} datasets)")
+
+    print("\n[2/3] Fetching clones.* files…")
+    clones_paths = [f"clones.{d['dataset_id']}.json" for d in manifest]
+    tree_idents: set[str] = set()
+    total_clone_bytes = 0
+    for path in clones_paths:
+        data = fetch(path)
+        save(path, data)
+        clones = json.loads(data)
+        for clone in clones:
+            for tree in clone.get("trees", []):
+                if "ident" in tree:
+                    tree_idents.add(tree["ident"])
+        total_clone_bytes += len(data)
+        print(f"  → {path} ({len(data):,} bytes, {len(clones)} clones)")
+
+    print(f"\n  total clones-file bytes: {total_clone_bytes:,}")
+    print(f"  unique tree idents to fetch: {len(tree_idents)}")
+
+    print(f"\n[3/3] Fetching {len(tree_idents)} tree files in parallel (×{PARALLELISM})…")
+    tree_paths = [f"tree.{ident}.json" for ident in sorted(tree_idents)]
+    ok = 0
+    failed: list[tuple[str, str]] = []
+    total_tree_bytes = 0
+    start = time.time()
+
+    with ThreadPoolExecutor(max_workers=PARALLELISM) as ex:
+        futures = {ex.submit(fetch_and_save, p): p for p in tree_paths}
+        for i, fut in enumerate(as_completed(futures), 1):
+            path, size, err = fut.result()
+            if err:
+                failed.append((path, err))
+            else:
+                ok += 1
+                total_tree_bytes += size
+            if i % 100 == 0 or i == len(tree_paths):
+                elapsed = time.time() - start
+                rate = i / elapsed if elapsed else 0
+                print(f"  [{i:>5}/{len(tree_paths)}] {ok} ok, {len(failed)} failed ({rate:.1f}/s)")
+
+    print("\n=== Summary ===")
+    print(f"  datasets:   1 ({len(manifest_bytes):,} bytes)")
+    print(f"  clones:     {len(clones_paths)} ({total_clone_bytes:,} bytes)")
+    print(f"  trees:      {ok} ({total_tree_bytes:,} bytes)")
+    if failed:
+        print(f"\n  {len(failed)} failures:")
+        for path, err in failed[:10]:
+            print(f"    {path}: {err}")
+        if len(failed) > 10:
+            print(f"    … and {len(failed) - 10} more")
+        sys.exit(1)
+    total = len(manifest_bytes) + total_clone_bytes + total_tree_bytes
+    print(f"\n  total:      {total:,} bytes ({total / 1024 / 1024:.1f} MB)")
+
+
+if __name__ == "__main__":
+    main()

--- a/bin/snapshot_server_data.py
+++ b/bin/snapshot_server_data.py
@@ -1,13 +1,19 @@
 #!/usr/bin/env python3
 """
-One-shot snapshot of the legacy olmstedviz.org datasets.
+Manifest-driven snapshot of the auspice-shaped server datasets.
 
-Crawls http://www.olmstedviz.org/data/, starting from the manifest, and
-saves a local copy under _data/server-snapshot/ preserving the URL layout.
+Reads `<base-url>/datasets.json`, then fetches the per-dataset
+`clones.{id}.json` and per-tree `tree.{ident}.json` files referenced
+indirectly through it. Preserves the URL layout under the output dir
+so the result can be served back via `npm run start:local <out>`.
+
+Defaults target the production olmstedviz.org bucket; both the base
+URL and the output dir are CLI-overridable for staging buckets or
+alternate local layouts.
 """
 
+import argparse
 import json
-import os
 import sys
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -15,41 +21,80 @@ from pathlib import Path
 from urllib.request import urlopen
 from urllib.error import HTTPError, URLError
 
-BASE_URL = "http://www.olmstedviz.org/data"
-OUT_DIR = Path(__file__).resolve().parent.parent / "_data" / "server-snapshot"
-PARALLELISM = 16
-TIMEOUT = 30
+DEFAULT_BASE_URL = "http://www.olmstedviz.org/data"
+DEFAULT_OUT_DIR = Path(__file__).resolve().parent.parent / "_data" / "server-snapshot"
+DEFAULT_PARALLELISM = 16
+DEFAULT_TIMEOUT = 30
 
 
-def fetch(path: str) -> bytes:
-    url = f"{BASE_URL}/{path}"
-    with urlopen(url, timeout=TIMEOUT) as resp:
+def fetch(base_url: str, path: str, timeout: int) -> bytes:
+    url = f"{base_url}/{path}"
+    with urlopen(url, timeout=timeout) as resp:
         return resp.read()
 
 
-def save(path: str, data: bytes) -> int:
-    out = OUT_DIR / path
+def save(out_dir: Path, path: str, data: bytes) -> int:
+    out = out_dir / path
     out.parent.mkdir(parents=True, exist_ok=True)
     out.write_bytes(data)
     return len(data)
 
 
-def fetch_and_save(path: str) -> tuple[str, int, str | None]:
+def fetch_and_save(base_url: str, out_dir: Path, timeout: int, path: str):
     try:
-        data = fetch(path)
-        size = save(path, data)
+        data = fetch(base_url, path, timeout)
+        size = save(out_dir, path, data)
         return path, size, None
     except (HTTPError, URLError, TimeoutError) as e:
         return path, 0, str(e)
 
 
+def parse_args():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument(
+        "-u",
+        "--base-url",
+        default=DEFAULT_BASE_URL,
+        help=f"URL prefix for the manifest and dataset files (default: {DEFAULT_BASE_URL})",
+    )
+    parser.add_argument(
+        "-o",
+        "--output",
+        type=Path,
+        default=DEFAULT_OUT_DIR,
+        help="Directory to save the snapshot into (default: %(default)s)",
+    )
+    parser.add_argument(
+        "-p",
+        "--parallelism",
+        type=int,
+        default=DEFAULT_PARALLELISM,
+        help=f"Concurrent tree-file fetches (default: {DEFAULT_PARALLELISM})",
+    )
+    parser.add_argument(
+        "-t",
+        "--timeout",
+        type=int,
+        default=DEFAULT_TIMEOUT,
+        help=f"Per-request timeout in seconds (default: {DEFAULT_TIMEOUT})",
+    )
+    return parser.parse_args()
+
+
 def main():
-    print(f"Snapshot target: {OUT_DIR}")
-    OUT_DIR.mkdir(parents=True, exist_ok=True)
+    args = parse_args()
+    base_url = args.base_url.rstrip("/")
+    out_dir = args.output
+    print(f"Source:         {base_url}")
+    print(f"Snapshot target: {out_dir}")
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     print("\n[1/3] Fetching manifest…")
-    manifest_bytes = fetch("datasets.json")
-    save("datasets.json", manifest_bytes)
+    manifest_bytes = fetch(base_url, "datasets.json", args.timeout)
+    save(out_dir, "datasets.json", manifest_bytes)
     manifest = json.loads(manifest_bytes)
     print(f"  → datasets.json ({len(manifest_bytes):,} bytes, {len(manifest)} datasets)")
 
@@ -58,8 +103,8 @@ def main():
     tree_idents: set[str] = set()
     total_clone_bytes = 0
     for path in clones_paths:
-        data = fetch(path)
-        save(path, data)
+        data = fetch(base_url, path, args.timeout)
+        save(out_dir, path, data)
         clones = json.loads(data)
         for clone in clones:
             for tree in clone.get("trees", []):
@@ -71,15 +116,15 @@ def main():
     print(f"\n  total clones-file bytes: {total_clone_bytes:,}")
     print(f"  unique tree idents to fetch: {len(tree_idents)}")
 
-    print(f"\n[3/3] Fetching {len(tree_idents)} tree files in parallel (×{PARALLELISM})…")
+    print(f"\n[3/3] Fetching {len(tree_idents)} tree files in parallel (×{args.parallelism})…")
     tree_paths = [f"tree.{ident}.json" for ident in sorted(tree_idents)]
     ok = 0
     failed: list[tuple[str, str]] = []
     total_tree_bytes = 0
     start = time.time()
 
-    with ThreadPoolExecutor(max_workers=PARALLELISM) as ex:
-        futures = {ex.submit(fetch_and_save, p): p for p in tree_paths}
+    with ThreadPoolExecutor(max_workers=args.parallelism) as ex:
+        futures = {ex.submit(fetch_and_save, base_url, out_dir, args.timeout, p): p for p in tree_paths}
         for i, fut in enumerate(as_completed(futures), 1):
             path, size, err = fut.result()
             if err:

--- a/server.js
+++ b/server.js
@@ -4,62 +4,77 @@ const express = require("express");
 const expressStaticGzip = require("express-static-gzip");
 const globals = require("./src/server/globals");
 const charon = require("./src/server/charon");
-const { execFile } = require('child_process');
+const { buildManifest } = require("./bin/build_datasets_manifest");
+const { execFile } = require("child_process");
 
 /* documentation in the static site! */
 
 // call like `npm start localData` or `npm start localData testdata` for a specific dir
 const devServer = process.argv.indexOf("dev") !== -1;
-let localDataIndex = process.argv.indexOf("localData")
+let localDataIndex = process.argv.indexOf("localData");
 let localData = localDataIndex !== -1;
-let localDataPath = localData ? (process.argv[localDataIndex + 1]) || "example_data/build_data" : undefined
-let port = (localData && process.argv[localDataIndex + 2]) || 3999
-globals.setGlobals({localData, localDataPath})
+let localDataPath = localData ? process.argv[localDataIndex + 1] || "example_data/build_data" : undefined;
+let port = (localData && process.argv[localDataIndex + 2]) || 3999;
+globals.setGlobals({ localData, localDataPath });
 
+// Auto-rebuild the local data manifest so users don't have to hand-edit
+// datasets.json after dropping a new consolidated file into the data dir.
+// Preserves legacy split-format entries; replaces consolidated entries.
+if (localData && localDataPath) {
+  try {
+    const result = buildManifest(localDataPath);
+    console.log(
+      `Rebuilt ${localDataPath}/datasets.json (${result.split.length} split + ${result.consolidated.length} consolidated)`
+    );
+  } catch (err) {
+    console.warn(`Could not rebuild manifest in ${localDataPath}: ${err.message}`);
+  }
+}
 
 /* if we are in dev-mode, we need to import specific libraries & set flags */
 
 const app = express();
-app.set('port', process.env.PORT || port);
-
-
+app.set("port", process.env.PORT || port);
 
 var options = {
-  dotfiles: 'ignore',
+  dotfiles: "ignore",
   etag: false,
-  extensions: ['gz'],
+  extensions: ["gz"],
   index: false,
-  maxAge: '1d',
+  maxAge: "1d",
   redirect: false,
   setHeaders: function (res, path, stat) {
-    res.set('Cache-Control', 'private')
+    res.set("Cache-Control", "private");
   }
-}
-
+};
 
 if (devServer) {
-
   let webpack = require("webpack"); // eslint-disable-line
   // Use dynamic require to avoid webpack bundling dev config in production
-  const configPath = process.env.WEBPACK_CONFIG || './webpack.config.dev';
+  const configPath = process.env.WEBPACK_CONFIG || "./webpack.config.dev";
   let webpackConfig = require(configPath);
 
   const compiler = webpack(webpackConfig);
 
-  app.use(require("webpack-dev-middleware")(compiler, {
-    publicPath: webpackConfig.output.publicPath
-  }));
+  app.use(
+    require("webpack-dev-middleware")(compiler, {
+      publicPath: webpackConfig.output.publicPath
+    })
+  );
 
-  app.use(require("webpack-hot-middleware")(compiler, {
-    log: console.log, path: '/__webpack_hmr', heartbeat: 10 * 1000
-  }));
+  app.use(
+    require("webpack-hot-middleware")(compiler, {
+      log: console.log,
+      path: "/__webpack_hmr",
+      heartbeat: 10 * 1000
+    })
+  );
 
   // Change this to zip data instead of dist
   if (global.LOCAL_DATA_PATH) {
     app.use("/data", expressStaticGzip(global.LOCAL_DATA_PATH, options));
   }
   app.use(express.static(path.join(__dirname, "dist")));
-
 } else {
   // zip up the source code for production
   app.use("/dist", expressStaticGzip("_deploy/dist"));
@@ -67,7 +82,7 @@ if (devServer) {
 }
 
 /* redirect www.nextstrain.org to nextstrain.org */
-app.use(require('express-naked-redirect')({reverse: true}));
+app.use(require("express-naked-redirect")({ reverse: true }));
 
 app.get("/favicon.png", (req, res) => {
   res.sendFile(path.join(__dirname, "favicon.png"));
@@ -80,10 +95,14 @@ app.get("{*path}", (req, res) => {
   res.sendFile(path.join(__dirname, "index.html"));
 });
 
-const server = app.listen(app.get('port'), () => {
+const server = app.listen(app.get("port"), () => {
   console.log("-----------------------------------");
   console.log("Olmsted server started on port " + server.address().port);
   console.log(devServer ? "Serving dev bundle with hot-reloading enabled" : "Serving compiled bundle from /dist");
-  console.log(global.LOCAL_DATA ? "Data is being sourced from " + global.LOCAL_DATA_PATH : "Dataset JSONs are being sourced from S3, narratives via the static github repo");
+  console.log(
+    global.LOCAL_DATA
+      ? "Data is being sourced from " + global.LOCAL_DATA_PATH
+      : "Dataset JSONs are being sourced from S3, narratives via the static github repo"
+  );
   console.log("-----------------------------------\n\n");
 });

--- a/server.js
+++ b/server.js
@@ -5,7 +5,6 @@ const expressStaticGzip = require("express-static-gzip");
 const globals = require("./src/server/globals");
 const charon = require("./src/server/charon");
 const { buildManifest } = require("./bin/build_datasets_manifest");
-const { execFile } = require("child_process");
 
 /* documentation in the static site! */
 
@@ -23,8 +22,9 @@ globals.setGlobals({ localData, localDataPath });
 if (localData && localDataPath) {
   try {
     const result = buildManifest(localDataPath);
+    const skippedSuffix = result.skipped > 0 ? `, ${result.skipped} skipped (see warnings above)` : "";
     console.log(
-      `Rebuilt ${localDataPath}/datasets.json (${result.split.length} split + ${result.consolidated.length} consolidated)`
+      `Rebuilt ${localDataPath}/datasets.json (${result.split.length} split + ${result.consolidated.length} consolidated${skippedSuffix})`
     );
   } catch (err) {
     console.warn(`Could not rebuild manifest in ${localDataPath}: ${err.message}`);

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -68,6 +68,25 @@ describe("ingestConsolidatedServerDataset", () => {
     expect(all[0].original_dataset_id).toBe("fixture-consolidated-001");
   });
 
+  it("marks server-ingested datasets as server-sourced and non-temporary", async () => {
+    const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
+    globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));
+
+    const stored = await ingestConsolidatedServerDataset({
+      dataset_id: "fixture-consolidated-001",
+      consolidated_path: "consolidated.fixture-consolidated-001.json"
+    });
+
+    // FileProcessor defaults are upload-style; ingest overrides them so the
+    // UI Source column can distinguish server-loaded from uploaded datasets.
+    expect(stored.isClientSide).toBe(false);
+    expect(stored.temporary).toBe(false);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all[0].isClientSide).toBe(false);
+    expect(all[0].temporary).toBe(false);
+  });
+
   it("short-circuits if the dataset is already in IndexedDB", async () => {
     const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
     globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -68,7 +68,7 @@ describe("ingestConsolidatedServerDataset", () => {
     expect(all[0].original_dataset_id).toBe("fixture-consolidated-001");
   });
 
-  it("marks server-ingested datasets as server-sourced and non-temporary", async () => {
+  it("marks server-ingested datasets as non-temporary while keeping isClientSide", async () => {
     const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
     globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));
 
@@ -77,13 +77,14 @@ describe("ingestConsolidatedServerDataset", () => {
       consolidated_path: "consolidated.fixture-consolidated-001.json"
     });
 
-    // FileProcessor defaults are upload-style; ingest overrides them so the
-    // UI Source column can distinguish server-loaded from uploaded datasets.
-    expect(stored.isClientSide).toBe(false);
+    // Server-ingested datasets live in IndexedDB (so isClientSide stays
+    // true — app.js routes loading by that flag), but temporary flips
+    // to false so the UI Source column reads "Server" rather than "Local".
+    expect(stored.isClientSide).toBe(true);
     expect(stored.temporary).toBe(false);
 
     const all = await olmstedDB.getAllDatasets();
-    expect(all[0].isClientSide).toBe(false);
+    expect(all[0].isClientSide).toBe(true);
     expect(all[0].temporary).toBe(false);
   });
 

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -1,0 +1,161 @@
+/**
+ * Tests for the consolidated server-side dataset ingestion path in
+ * clientDataLoader.js. The function fetches a manifest entry's
+ * `consolidated_path`, wraps the response as a File, and runs it through
+ * the same FileProcessor pipeline as in-browser uploads, then stores
+ * the result in IndexedDB via olmstedDB.
+ *
+ * Tests use fake-indexeddb (via jest.setup.js) and a mocked global fetch.
+ */
+
+import fs from "fs";
+import path from "path";
+
+// src/util/globals.js pulls in d3-scale (ESM-only) for unrelated color
+// constants; mock just the API constant we actually use here.
+jest.mock("../../util/globals", () => ({
+  charonAPIAddress: "/data"
+}));
+
+const { ingestConsolidatedServerDataset, ingestConsolidatedServerDatasets } = require("../clientDataLoader");
+const olmstedDB = require("../../utils/olmstedDB").default;
+
+const FIXTURE_DIR = path.resolve(__dirname, "../../server/__tests__/__fixtures__/server-data");
+
+const readFixture = (name) => fs.readFileSync(path.join(FIXTURE_DIR, name), "utf8");
+
+// Stub Response with the minimal surface the implementation uses: ok, status,
+// statusText, json(), blob(). Blob() returns a real Blob (jsdom provides it).
+const mockResponse = (text, { ok = true, status = 200, statusText = "OK" } = {}) => ({
+  ok,
+  status,
+  statusText,
+  json: async () => JSON.parse(text),
+  blob: async () => new Blob([text], { type: "application/json" })
+});
+
+describe("ingestConsolidatedServerDataset", () => {
+  let originalFetch;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    await olmstedDB.ready;
+    await olmstedDB.clearAll();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("fetches the consolidated file and stores it in IndexedDB", async () => {
+    const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
+    globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));
+
+    const entry = {
+      dataset_id: "fixture-consolidated-001",
+      consolidated_path: "consolidated.fixture-consolidated-001.json"
+    };
+    const stored = await ingestConsolidatedServerDataset(entry);
+
+    expect(globalThis.fetch).toHaveBeenCalledWith("/data/consolidated.fixture-consolidated-001.json");
+    expect(stored).toBeTruthy();
+    // The storage layer preserves original_dataset_id so subsequent loads can dedupe.
+    expect(stored.original_dataset_id).toBe("fixture-consolidated-001");
+
+    // The dataset is now actually in IndexedDB.
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].original_dataset_id).toBe("fixture-consolidated-001");
+  });
+
+  it("short-circuits if the dataset is already in IndexedDB", async () => {
+    const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
+    globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));
+
+    const entry = {
+      dataset_id: "fixture-consolidated-001",
+      consolidated_path: "consolidated.fixture-consolidated-001.json"
+    };
+
+    // First call ingests, second should not refetch.
+    await ingestConsolidatedServerDataset(entry);
+    await ingestConsolidatedServerDataset(entry);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(await olmstedDB.datasets.count()).toBe(1);
+  });
+
+  it("returns null and does not throw when the fetch fails", async () => {
+    globalThis.fetch = jest.fn(async () => mockResponse("", { ok: false, status: 404, statusText: "Not Found" }));
+
+    const stored = await ingestConsolidatedServerDataset({
+      dataset_id: "missing",
+      consolidated_path: "missing.json"
+    });
+
+    expect(stored).toBeNull();
+    expect(await olmstedDB.datasets.count()).toBe(0);
+  });
+
+  it("returns null and does not throw when FileProcessor rejects the payload", async () => {
+    globalThis.fetch = jest.fn(async () => mockResponse("not valid json at all"));
+
+    const stored = await ingestConsolidatedServerDataset({
+      dataset_id: "bogus",
+      consolidated_path: "bogus.json"
+    });
+
+    expect(stored).toBeNull();
+    expect(await olmstedDB.datasets.count()).toBe(0);
+  });
+});
+
+describe("ingestConsolidatedServerDatasets (manifest-driven)", () => {
+  let originalFetch;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    await olmstedDB.ready;
+    await olmstedDB.clearAll();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("ingests only entries with consolidated_path and returns the rest", async () => {
+    const manifestText = readFixture("datasets.json");
+    const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
+
+    globalThis.fetch = jest.fn(async (url) => {
+      if (url.endsWith("datasets.json")) return mockResponse(manifestText);
+      if (url.endsWith("consolidated.fixture-consolidated-001.json")) return mockResponse(consolidatedText);
+      return mockResponse("", { ok: false, status: 404 });
+    });
+
+    const splitOnly = await ingestConsolidatedServerDatasets();
+
+    // The fixture manifest has two entries; one has consolidated_path, one
+    // doesn't. The split-only entry is the one without.
+    expect(splitOnly).toHaveLength(1);
+    expect(splitOnly[0].dataset_id).toBe("fixture-dataset-001");
+    expect(splitOnly[0].consolidated_path).toBeUndefined();
+
+    // The consolidated entry was ingested into IndexedDB.
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].original_dataset_id).toBe("fixture-consolidated-001");
+  });
+
+  it("returns [] when the manifest fetch fails", async () => {
+    globalThis.fetch = jest.fn(async () => mockResponse("", { ok: false, status: 500 }));
+    const result = await ingestConsolidatedServerDatasets();
+    expect(result).toEqual([]);
+  });
+
+  it("returns [] when the manifest is not an array", async () => {
+    globalThis.fetch = jest.fn(async () => mockResponse(JSON.stringify({ not: "an array" })));
+    const result = await ingestConsolidatedServerDatasets();
+    expect(result).toEqual([]);
+  });
+});

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -68,7 +68,7 @@ describe("ingestConsolidatedServerDataset", () => {
     expect(all[0].original_dataset_id).toBe("fixture-consolidated-001");
   });
 
-  it("marks server-ingested datasets as non-temporary while keeping isClientSide", async () => {
+  it("marks server-ingested datasets as SERVER_CONSOLIDATED source", async () => {
     const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
     globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));
 
@@ -77,13 +77,15 @@ describe("ingestConsolidatedServerDataset", () => {
       consolidated_path: "consolidated.fixture-consolidated-001.json"
     });
 
-    // Server-ingested datasets live in IndexedDB (so isClientSide stays
-    // true — app.js routes loading by that flag), but temporary flips
-    // to false so the UI Source column reads "Server" rather than "Local".
+    // `source` is the load-bearing field for Source labeling and loader
+    // routing. The legacy booleans are kept in sync for backward compat
+    // with already-persisted IndexedDB records.
+    expect(stored.source).toBe("server-consolidated");
     expect(stored.isClientSide).toBe(true);
     expect(stored.temporary).toBe(false);
 
     const all = await olmstedDB.getAllDatasets();
+    expect(all[0].source).toBe("server-consolidated");
     expect(all[0].isClientSide).toBe(true);
     expect(all[0].temporary).toBe(false);
   });

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -5,6 +5,8 @@
 
 import * as types from "./types";
 import clientDataStore from "../utils/clientDataStore";
+import olmstedDB from "../utils/olmstedDB";
+import FileProcessor from "../utils/fileProcessor";
 import { charonAPIAddress } from "../util/globals";
 
 /**
@@ -94,12 +96,81 @@ export const getClientClonalFamilies = async (dispatch, dataset_id) => {
 };
 
 /**
+ * Fetch a consolidated server-side dataset file (olmsted-cli JSON or .json.gz),
+ * route it through the upload pipeline, and store in IndexedDB. Subsequent
+ * calls for the same `original_dataset_id` short-circuit.
+ *
+ * @param {Object} entry - Manifest entry with consolidated_path + dataset_id
+ * @returns {Promise<Object|null>} The stored dataset record, or null on failure
+ */
+export const ingestConsolidatedServerDataset = async (entry) => {
+  try {
+    const existing = await olmstedDB.findDatasetByOriginalId(entry.dataset_id);
+    if (existing) return existing;
+
+    const url = `${charonAPIAddress}/${entry.consolidated_path}`;
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.warn(`Failed to fetch consolidated server dataset at ${url}: ${response.status} ${response.statusText}`);
+      return null;
+    }
+
+    const blob = await response.blob();
+    const filename = entry.consolidated_path.split("/").pop();
+    const file = new File([blob], filename, { type: blob.type });
+    const result = await FileProcessor.processFile(file);
+    await clientDataStore.storeProcessedData(result);
+    return result.datasets[0];
+  } catch (error) {
+    console.warn(`Failed to ingest consolidated server dataset ${entry.dataset_id}:`, error);
+    return null;
+  }
+};
+
+/**
+ * Read /data/datasets.json and ingest any entries that point at a consolidated
+ * olmsted-cli file via `consolidated_path`. Returns the list of split-only
+ * manifest entries (those without consolidated_path), so the caller can
+ * continue with the legacy split-format flow for them.
+ *
+ * @returns {Promise<Array>} split-only entries, or [] on any failure
+ */
+export const ingestConsolidatedServerDatasets = async () => {
+  try {
+    const response = await fetch(`${charonAPIAddress}/datasets.json`);
+    if (!response.ok) return [];
+    const manifest = await response.json();
+    if (!Array.isArray(manifest)) return [];
+
+    const consolidated = manifest.filter((d) => d.consolidated_path);
+    const splitOnly = manifest.filter((d) => !d.consolidated_path);
+
+    for (const entry of consolidated) {
+      // Sequential to avoid hammering the same Express dev server with many
+      // parallel fetch+ingest cycles on first page load.
+      await ingestConsolidatedServerDataset(entry);
+    }
+
+    return splitOnly;
+  } catch (error) {
+    console.warn("Failed to load consolidated server datasets:", error);
+    return [];
+  }
+};
+
+/**
  * Get datasets list from client storage (replaces server getDatasets)
  * @param {Function} dispatch - Redux dispatch function
  * @param {string} _s3bucket - Legacy parameter for server compatibility (ignored)
  */
 export const getClientDatasets = async (dispatch, _s3bucket = "live") => {
   try {
+    // Ingest any consolidated-format server datasets first. After this, those
+    // entries are in IndexedDB and surface naturally through the client list.
+    // The returned list is the split-only manifest entries (auspice-shaped),
+    // which the existing loadServerDatasets path continues to handle.
+    await ingestConsolidatedServerDatasets();
+
     const clientDatasets = await clientDataStore.getAllDatasets();
 
     // Process client datasets

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -119,6 +119,15 @@ export const ingestConsolidatedServerDataset = async (entry) => {
     const filename = entry.consolidated_path.split("/").pop();
     const file = new File([blob], filename, { type: blob.type });
     const result = await FileProcessor.processFile(file);
+
+    // FileProcessor defaults to upload-style flags (isClientSide: true,
+    // temporary: true). Server-loaded datasets should be distinguishable
+    // in the UI Source column and persist across "delete uploads" actions.
+    if (result.datasets && result.datasets[0]) {
+      result.datasets[0].isClientSide = false;
+      result.datasets[0].temporary = false;
+    }
+
     await clientDataStore.storeProcessedData(result);
     return result.datasets[0];
   } catch (error) {
@@ -173,11 +182,13 @@ export const getClientDatasets = async (dispatch, _s3bucket = "live") => {
 
     const clientDatasets = await clientDataStore.getAllDatasets();
 
-    // Process client datasets
+    // Default to upload-style flags, but respect any explicit values
+    // stored on the dataset record itself (server-ingested entries
+    // store isClientSide: false so the Source column reads "Server").
     const availableDatasets = clientDatasets.map((dataset) => ({
-      ...dataset,
-      isClientSide: true, // Mark as client-side for UI distinction
-      temporary: true
+      isClientSide: true,
+      temporary: true,
+      ...dataset
     }));
 
     if (availableDatasets.length > 0) {
@@ -206,13 +217,15 @@ export const getClientDatasets = async (dispatch, _s3bucket = "live") => {
  * This allows mixing client-side and server-side data
  */
 const loadServerDatasets = async (dispatch) => {
-  // Helper function to get client datasets and format them
+  // Helper function to get client datasets and format them. Defaults to
+  // upload-style flags, but respects stored values so server-ingested
+  // datasets keep their `isClientSide: false` marker.
   const getClientOnlyDatasets = async () => {
     const clientDatasets = await clientDataStore.getAllDatasets();
     return clientDatasets.map((d) => ({
-      ...d,
       isClientSide: true,
-      temporary: true
+      temporary: true,
+      ...d
     }));
   };
 
@@ -231,7 +244,12 @@ const loadServerDatasets = async (dispatch) => {
 
         if (isJson || request.responseText.trim().startsWith("[") || request.responseText.trim().startsWith("{")) {
           try {
-            const serverDatasets = JSON.parse(request.responseText);
+            // Drop consolidated entries — those have already been ingested
+            // into IndexedDB by ingestConsolidatedServerDatasets and surface
+            // through the client list above (with isClientSide: false).
+            // Including them here would duplicate the row and produce
+            // mismatched Source labels for the same dataset.
+            const serverDatasets = JSON.parse(request.responseText).filter((d) => !d.consolidated_path);
 
             // Combine client and server datasets
             const combinedDatasets = [...clientDatasets, ...serverDatasets.map((d) => ({ ...d, isClientSide: false }))];

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -121,10 +121,11 @@ export const ingestConsolidatedServerDataset = async (entry) => {
     const result = await FileProcessor.processFile(file);
 
     // FileProcessor defaults to upload-style flags (isClientSide: true,
-    // temporary: true). Server-loaded datasets should be distinguishable
-    // in the UI Source column and persist across "delete uploads" actions.
+    // temporary: true). Server-loaded datasets stay isClientSide: true
+    // because they DO live in IndexedDB — routing in app.js uses that
+    // flag to choose the right loader — but `temporary` flips to false
+    // so the UI Source column can read "Server".
     if (result.datasets && result.datasets[0]) {
-      result.datasets[0].isClientSide = false;
       result.datasets[0].temporary = false;
     }
 

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -8,6 +8,77 @@ import clientDataStore from "../utils/clientDataStore";
 import olmstedDB from "../utils/olmstedDB";
 import FileProcessor from "../utils/fileProcessor";
 import { charonAPIAddress } from "../util/globals";
+import { DATASET_SOURCE } from "../constants/datasetSource";
+
+/**
+ * Predicate identifying a manifest entry that points at a single
+ * consolidated olmsted-cli file (`.json` / `.json.gz`) under the data
+ * root, rather than the legacy split-format (per-dataset clones files
+ * + per-tree files). The wire contract is a single `consolidated_path`
+ * field on the entry.
+ */
+const isConsolidatedEntry = (entry) => Boolean(entry && entry.consolidated_path);
+
+/**
+ * Fetch the `/data/datasets.json` manifest once. Returns the parsed
+ * array, or null on any failure (network, non-OK status, non-JSON
+ * body, non-array shape). The caller decides how to handle the
+ * absence of a manifest — the typical answer is "use whatever's in
+ * IndexedDB and skip server datasets."
+ */
+const fetchManifest = async () => {
+  try {
+    const response = await fetch(`${charonAPIAddress}/datasets.json`);
+    if (!response.ok) return null;
+    const manifest = await response.json();
+    return Array.isArray(manifest) ? manifest : null;
+  } catch (err) {
+    console.warn("Failed to fetch server manifest:", err);
+    return null;
+  }
+};
+
+/**
+ * Normalize a dataset record (from IndexedDB) for dispatch. Defaults
+ * to upload-style flags but respects any stored values via `??` so
+ * server-ingested entries keep their `temporary: false` marker. Also
+ * ensures `source` is set (derived from legacy flags for back-compat
+ * with records persisted before the source enum landed).
+ */
+const mapClientDatasetForDispatch = (dataset) => ({
+  ...dataset,
+  isClientSide: dataset.isClientSide ?? true,
+  temporary: dataset.temporary ?? true,
+  source: dataset.source ?? (dataset.temporary === false ? DATASET_SOURCE.SERVER_CONSOLIDATED : DATASET_SOURCE.UPLOAD)
+});
+
+/**
+ * Map a legacy split-format manifest entry into a dispatched dataset
+ * record. The data still lives on the server (lazy-loaded per request
+ * via the auspice-shaped Charon endpoints), not in IndexedDB.
+ */
+const mapServerSplitEntryForDispatch = (entry) => ({
+  ...entry,
+  isClientSide: false,
+  source: DATASET_SOURCE.SERVER_SPLIT
+});
+
+/**
+ * Read IndexedDB + the supplied split-format manifest entries, combine
+ * them into a single availableDatasets list, and dispatch.
+ */
+const dispatchCombinedDatasets = async (dispatch, splitEntries, options = {}) => {
+  const clientDatasets = await clientDataStore.getAllDatasets();
+  const availableDatasets = [
+    ...clientDatasets.map(mapClientDatasetForDispatch),
+    ...splitEntries.map(mapServerSplitEntryForDispatch)
+  ];
+  dispatch({
+    type: types.DATASETS_RECEIVED,
+    availableDatasets,
+    preserveLoadingStatus: options.preserveLoadingStatus ?? true
+  });
+};
 
 /**
  * Get tree data from client storage (replaces server getTree)
@@ -120,12 +191,12 @@ export const ingestConsolidatedServerDataset = async (entry) => {
     const file = new File([blob], filename, { type: blob.type });
     const result = await FileProcessor.processFile(file);
 
-    // FileProcessor defaults to upload-style flags (isClientSide: true,
-    // temporary: true). Server-loaded datasets stay isClientSide: true
-    // because they DO live in IndexedDB — routing in app.js uses that
-    // flag to choose the right loader — but `temporary` flips to false
-    // so the UI Source column can read "Server".
+    // FileProcessor sets source = UPLOAD; override to SERVER_CONSOLIDATED.
+    // `temporary` is flipped to false so the Source column reads "Server".
+    // `isClientSide` stays true so app.js routes loading via the IndexedDB
+    // loader, not the legacy auspice fetch flow.
     if (result.datasets && result.datasets[0]) {
+      result.datasets[0].source = DATASET_SOURCE.SERVER_CONSOLIDATED;
       result.datasets[0].temporary = false;
     }
 
@@ -138,180 +209,79 @@ export const ingestConsolidatedServerDataset = async (entry) => {
 };
 
 /**
- * Read /data/datasets.json and ingest any entries that point at a consolidated
- * olmsted-cli file via `consolidated_path`. Returns the list of split-only
- * manifest entries (those without consolidated_path), so the caller can
- * continue with the legacy split-format flow for them.
+ * Ingest the consolidated entries from a manifest sequentially, then
+ * re-dispatch once any were stored so newly-arrived datasets surface
+ * in the UI without a page reload. Background work — callers don't
+ * need to await this.
  *
- * @returns {Promise<Array>} split-only entries, or [] on any failure
+ * @param {Array<Object>} consolidatedEntries
+ * @param {Array<Object>} splitEntries - passed through to the re-dispatch
+ * @param {Function} dispatch
  */
-export const ingestConsolidatedServerDatasets = async () => {
-  try {
-    const response = await fetch(`${charonAPIAddress}/datasets.json`);
-    if (!response.ok) return [];
-    const manifest = await response.json();
-    if (!Array.isArray(manifest)) return [];
-
-    const consolidated = manifest.filter((d) => d.consolidated_path);
-    const splitOnly = manifest.filter((d) => !d.consolidated_path);
-
-    for (const entry of consolidated) {
-      // Sequential to avoid hammering the same Express dev server with many
-      // parallel fetch+ingest cycles on first page load.
-      await ingestConsolidatedServerDataset(entry);
-    }
-
-    return splitOnly;
-  } catch (error) {
-    console.warn("Failed to load consolidated server datasets:", error);
-    return [];
+const ingestAndDispatch = async (consolidatedEntries, splitEntries, dispatch) => {
+  let ingestedAny = false;
+  for (const entry of consolidatedEntries) {
+    // Sequential to avoid hammering the dev server with many parallel
+    // fetch+ingest cycles on first page load.
+    const stored = await ingestConsolidatedServerDataset(entry);
+    if (stored) ingestedAny = true;
+  }
+  if (ingestedAny) {
+    await dispatchCombinedDatasets(dispatch, splitEntries);
   }
 };
 
 /**
- * Get datasets list from client storage (replaces server getDatasets)
+ * Read /data/datasets.json and ingest any entries with consolidated_path.
+ * Kept as an exported helper for tests; the production code path goes
+ * through `getClientDatasets` instead, which is non-blocking.
+ *
+ * @returns {Promise<Array>} split-only entries, or [] on any failure
+ */
+export const ingestConsolidatedServerDatasets = async () => {
+  const manifest = await fetchManifest();
+  if (!manifest) return [];
+  const consolidatedEntries = manifest.filter(isConsolidatedEntry);
+  const splitEntries = manifest.filter((d) => !isConsolidatedEntry(d));
+  for (const entry of consolidatedEntries) {
+    await ingestConsolidatedServerDataset(entry);
+  }
+  return splitEntries;
+};
+
+/**
+ * Get datasets list from client storage (replaces server getDatasets).
+ * Single manifest fetch, dispatches an initial combined client +
+ * server-split list immediately, then ingests consolidated server
+ * datasets in the background and re-dispatches when each arrives.
+ *
  * @param {Function} dispatch - Redux dispatch function
  * @param {string} _s3bucket - Legacy parameter for server compatibility (ignored)
  */
 export const getClientDatasets = async (dispatch, _s3bucket = "live") => {
   try {
-    // Ingest any consolidated-format server datasets first. After this, those
-    // entries are in IndexedDB and surface naturally through the client list.
-    // The returned list is the split-only manifest entries (auspice-shaped),
-    // which the existing loadServerDatasets path continues to handle.
-    await ingestConsolidatedServerDatasets();
+    const manifest = (await fetchManifest()) || [];
+    const splitEntries = manifest.filter((d) => !isConsolidatedEntry(d));
+    const consolidatedEntries = manifest.filter(isConsolidatedEntry);
 
-    const clientDatasets = await clientDataStore.getAllDatasets();
+    // Initial dispatch with whatever's already in IndexedDB + the
+    // split-format manifest entries. Don't wait on consolidated ingest.
+    await dispatchCombinedDatasets(dispatch, splitEntries);
 
-    // Default to upload-style flags, but respect any explicit values
-    // stored on the dataset record itself (server-ingested entries
-    // store isClientSide: false so the Source column reads "Server").
-    const availableDatasets = clientDatasets.map((dataset) => ({
-      isClientSide: true,
-      temporary: true,
-      ...dataset
-    }));
-
-    if (availableDatasets.length > 0) {
-      // If we have client datasets, dispatch them immediately
-      dispatch({
-        type: types.DATASETS_RECEIVED,
-        availableDatasets,
-        preserveLoadingStatus: true // Preserve existing loading status when updating datasets
-      });
+    // Background: fetch + ingest each consolidated dataset, then
+    // re-dispatch so the new IndexedDB rows surface in the UI.
+    if (consolidatedEntries.length > 0) {
+      ingestAndDispatch(consolidatedEntries, splitEntries, dispatch);
     }
-
-    // Always attempt to load server datasets in parallel
-    // This allows mixing client-side uploaded data with server-side data
-    // eslint-disable-next-line no-use-before-define
-    loadServerDatasets(dispatch);
   } catch (error) {
     console.error("Error loading client datasets:", error);
-    // Fallback to server-only loading
-    // eslint-disable-next-line no-use-before-define
-    loadServerDatasets(dispatch);
-  }
-};
-
-/**
- * Load server datasets (original functionality)
- * This allows mixing client-side and server-side data
- */
-const loadServerDatasets = async (dispatch) => {
-  // Helper function to get client datasets and format them. Defaults to
-  // upload-style flags, but respects stored values so server-ingested
-  // datasets keep their `isClientSide: false` marker.
-  const getClientOnlyDatasets = async () => {
-    const clientDatasets = await clientDataStore.getAllDatasets();
-    return clientDatasets.map((d) => ({
-      isClientSide: true,
-      temporary: true,
-      ...d
-    }));
-  };
-
-  try {
-    // Get client datasets first
-    const clientDatasets = await getClientOnlyDatasets();
-
-    // Use the original server loading logic as fallback
-    const request = new XMLHttpRequest();
-
-    request.onload = () => {
-      if (request.readyState === 4 && request.status === 200) {
-        // Check if response is JSON before trying to parse
-        const contentType = request.getResponseHeader("content-type");
-        const isJson = contentType && contentType.includes("application/json");
-
-        if (isJson || request.responseText.trim().startsWith("[") || request.responseText.trim().startsWith("{")) {
-          try {
-            // Drop consolidated entries — those have already been ingested
-            // into IndexedDB by ingestConsolidatedServerDatasets and surface
-            // through the client list above (with isClientSide: false).
-            // Including them here would duplicate the row and produce
-            // mismatched Source labels for the same dataset.
-            const serverDatasets = JSON.parse(request.responseText).filter((d) => !d.consolidated_path);
-
-            // Combine client and server datasets
-            const combinedDatasets = [...clientDatasets, ...serverDatasets.map((d) => ({ ...d, isClientSide: false }))];
-
-            dispatch({
-              type: types.DATASETS_RECEIVED,
-              availableDatasets: combinedDatasets
-            });
-
-            console.log("Combined datasets loaded:", {
-              client: clientDatasets.length,
-              server: serverDatasets.length,
-              total: combinedDatasets.length
-            });
-          } catch (_error) {
-            // Silently fall back to client-only datasets
-            if (clientDatasets.length > 0) {
-              dispatch({
-                type: types.DATASETS_RECEIVED,
-                availableDatasets: clientDatasets,
-                preserveLoadingStatus: true
-              });
-            }
-          }
-        } else {
-          // Response is not JSON (likely HTML error page), use client-only datasets
-          dispatch({
-            type: types.DATASETS_RECEIVED,
-            availableDatasets: clientDatasets,
-            preserveLoadingStatus: true
-          });
-        }
-      } else {
-        // Server request failed, use client-only datasets
-        dispatch({
-          type: types.DATASETS_RECEIVED,
-          availableDatasets: clientDatasets,
-          preserveLoadingStatus: true
-        });
-      }
-    };
-
-    request.onerror = () => {
-      // Network error, use client-only datasets
-      dispatch({
-        type: types.DATASETS_RECEIVED,
-        availableDatasets: clientDatasets,
-        preserveLoadingStatus: true
-      });
-    };
-
-    // Load from server API (original endpoint)
-    request.open("get", `${charonAPIAddress}/datasets.json`, true);
-    request.send(null);
-  } catch (error) {
-    // If even client dataset loading fails, dispatch empty array
-    console.error("Failed to load client datasets:", error);
-    dispatch({
-      type: types.DATASETS_RECEIVED,
-      availableDatasets: []
-    });
+    // Last-resort fallback: dispatch whatever's in IndexedDB alone.
+    try {
+      await dispatchCombinedDatasets(dispatch, []);
+    } catch (innerError) {
+      console.error("Failed to load client datasets:", innerError);
+      dispatch({ type: types.DATASETS_RECEIVED, availableDatasets: [] });
+    }
   }
 };
 
@@ -349,6 +319,7 @@ export const clearClientData = (dispatch) => {
   clientDataStore.clearAllData();
   console.log("Cleared all client-side data");
 
-  // Reload datasets to show only server data
-  loadServerDatasets(dispatch);
+  // Reload datasets so the UI reflects the now-empty IndexedDB plus
+  // whatever's in the server manifest.
+  getClientDatasets(dispatch);
 };

--- a/src/components/explorer/DatasetLoadingTable.js
+++ b/src/components/explorer/DatasetLoadingTable.js
@@ -507,7 +507,9 @@ export default class DatasetLoadingTable extends React.Component {
     // Filter datasets
     let filteredDatasets = allDatasetsRaw;
     if (hideServerData) {
-      filteredDatasets = filteredDatasets.filter((d) => d.isClientSide || d.temporary);
+      // Only user uploads (temporary: true) are kept; server-ingested and
+      // legacy auspice entries both count as server data.
+      filteredDatasets = filteredDatasets.filter((d) => d.temporary);
     }
     if (showOnlyStarred) {
       filteredDatasets = filteredDatasets.filter((d) => starredDatasets.includes(d.dataset_id));
@@ -534,8 +536,11 @@ export default class DatasetLoadingTable extends React.Component {
       ["Name", (d) => d.name || d.dataset_id, { sortKey: "name" }],
       [
         "Source",
-        (d) => (d.isClientSide || d.temporary ? "Local" : "Server"),
-        { style: { fontSize: "12px" }, sortKey: "isClientSide" }
+        // `temporary: true` flags a user-uploaded dataset (Local).
+        // Everything else — server-ingested consolidated and legacy
+        // auspice manifest entries — labels as Server.
+        (d) => (d.temporary ? "Local" : "Server"),
+        { style: { fontSize: "12px" }, sortKey: "temporary" }
       ],
       ["Size (MB)", SizeCell, { sortKey: "file_size", style: { textAlign: "right" } }],
       ["Subjects", "subjects_count"],

--- a/src/components/explorer/DatasetLoadingTable.js
+++ b/src/components/explorer/DatasetLoadingTable.js
@@ -11,6 +11,7 @@ import * as explorerActions from "../../actions/explorer";
 import { changePage } from "../../actions/navigation";
 import { resolveFieldMetadata } from "../../utils/fieldMetadata";
 import { DEFAULT_DISPLAY, DISPLAY_MODE_ICONS } from "../../constants/fieldDefaults";
+import { isUserUpload, isDatasetInIndexedDB } from "../../constants/datasetSource";
 import * as types from "../../actions/types";
 import DownloadCSV from "../util/downloadCsv";
 import {
@@ -264,7 +265,7 @@ export default class DatasetLoadingTable extends React.Component {
         dispatch({ type: types.LOADING_DATASET, dataset_id, loading: "LOADING" });
 
         try {
-          if (dataset.isClientSide) {
+          if (isDatasetInIndexedDB(dataset)) {
             await getClientClonalFamilies(dispatch, dataset_id);
             // Success is handled by getClientClonalFamilies dispatch
           } else {
@@ -507,9 +508,7 @@ export default class DatasetLoadingTable extends React.Component {
     // Filter datasets
     let filteredDatasets = allDatasetsRaw;
     if (hideServerData) {
-      // Only user uploads (temporary: true) are kept; server-ingested and
-      // legacy auspice entries both count as server data.
-      filteredDatasets = filteredDatasets.filter((d) => d.temporary);
+      filteredDatasets = filteredDatasets.filter(isUserUpload);
     }
     if (showOnlyStarred) {
       filteredDatasets = filteredDatasets.filter((d) => starredDatasets.includes(d.dataset_id));
@@ -534,14 +533,7 @@ export default class DatasetLoadingTable extends React.Component {
       ["Status", LoadStatusDisplay, { sortable: false }],
       ["Info", DatasetInfoCell, { sortable: false }],
       ["Name", (d) => d.name || d.dataset_id, { sortKey: "name" }],
-      [
-        "Source",
-        // `temporary: true` flags a user-uploaded dataset (Local).
-        // Everything else — server-ingested consolidated and legacy
-        // auspice manifest entries — labels as Server.
-        (d) => (d.temporary ? "Local" : "Server"),
-        { style: { fontSize: "12px" }, sortKey: "temporary" }
-      ],
+      ["Source", (d) => (isUserUpload(d) ? "Local" : "Server"), { style: { fontSize: "12px" }, sortKey: "source" }],
       ["Size (MB)", SizeCell, { sortKey: "file_size", style: { textAlign: "right" } }],
       ["Subjects", "subjects_count"],
       ["Families", "clone_count"],

--- a/src/components/explorer/app.js
+++ b/src/components/explorer/app.js
@@ -6,6 +6,7 @@ import * as clonalFamiliesSelectors from "../../selectors/clonalFamilies";
 import * as explorerActions from "../../actions/explorer";
 import { getClientDatasets, getClientClonalFamilies } from "../../actions/clientDataLoader";
 import * as loadData from "../../actions/loadData";
+import { isDatasetInIndexedDB } from "../../constants/datasetSource";
 import * as types from "../../actions/types";
 import { TreeViz } from "./tree";
 import { ClonalFamiliesViz } from "./scatterplot";
@@ -652,8 +653,10 @@ class App extends React.Component {
         if (dataset) {
           dispatch({ type: types.LOADING_DATASET, dataset_id, loading: "LOADING" });
 
-          // Use appropriate loader based on dataset type
-          if (dataset.isClientSide) {
+          // Datasets backed by IndexedDB (uploads and consolidated-server
+          // ingest) use the client loader. Legacy split-format manifest
+          // entries fall through to the auspice fetch flow.
+          if (isDatasetInIndexedDB(dataset)) {
             getClientClonalFamilies(dispatch, dataset_id);
           } else {
             loadData.getClonalFamilies(dispatch, dataset_id);

--- a/src/components/splash/DatasetManagementTable.js
+++ b/src/components/splash/DatasetManagementTable.js
@@ -238,7 +238,9 @@ class DatasetManagementTableComponent extends React.Component {
     // Filter datasets
     let filteredDatasets = availableDatasets;
     if (hideServerData) {
-      filteredDatasets = filteredDatasets.filter((d) => d.isClientSide || d.temporary);
+      // Only user uploads (temporary: true) are kept; server-ingested and
+      // legacy auspice entries both count as server data.
+      filteredDatasets = filteredDatasets.filter((d) => d.temporary);
     }
     if (showOnlyStarred) {
       filteredDatasets = filteredDatasets.filter((d) => starredDatasets.includes(d.dataset_id));
@@ -258,8 +260,11 @@ class DatasetManagementTableComponent extends React.Component {
       ["Name", (d) => d.name || d.dataset_id, { sortKey: "name" }],
       [
         "Source",
-        (d) => (d.isClientSide || d.temporary ? "Local" : "Server"),
-        { style: { fontSize: "12px" }, sortKey: "isClientSide" }
+        // `temporary: true` flags a user-uploaded dataset (Local).
+        // Everything else — server-ingested consolidated and legacy
+        // auspice manifest entries — labels as Server.
+        (d) => (d.temporary ? "Local" : "Server"),
+        { style: { fontSize: "12px" }, sortKey: "temporary" }
       ],
       ["Size (MB)", SizeCell, { sortKey: "file_size", style: { textAlign: "right" } }],
       ["Subjects", "subjects_count"],

--- a/src/components/splash/DatasetManagementTable.js
+++ b/src/components/splash/DatasetManagementTable.js
@@ -8,6 +8,7 @@ import { getClientClonalFamilies } from "../../actions/clientDataLoader";
 import clientDataStore from "../../utils/clientDataStore";
 import * as types from "../../actions/types";
 import * as explorerActions from "../../actions/explorer";
+import { isUserUpload, isDatasetInIndexedDB } from "../../constants/datasetSource";
 import { LoadingStatus } from "../util/loading";
 import { ResizableTable } from "../util/resizableTable";
 import DownloadCSV from "../util/downloadCsv";
@@ -61,8 +62,7 @@ class LoadStatusCell extends React.Component {
           loading: "LOADING"
         });
 
-        // Try client-side data first, fallback to server
-        if (dataset.isClientSide) {
+        if (isDatasetInIndexedDB(dataset)) {
           getClientClonalFamilies(dispatch, dataset.dataset_id);
         } else {
           getClonalFamilies(dispatch, dataset.dataset_id);
@@ -238,9 +238,7 @@ class DatasetManagementTableComponent extends React.Component {
     // Filter datasets
     let filteredDatasets = availableDatasets;
     if (hideServerData) {
-      // Only user uploads (temporary: true) are kept; server-ingested and
-      // legacy auspice entries both count as server data.
-      filteredDatasets = filteredDatasets.filter((d) => d.temporary);
+      filteredDatasets = filteredDatasets.filter(isUserUpload);
     }
     if (showOnlyStarred) {
       filteredDatasets = filteredDatasets.filter((d) => starredDatasets.includes(d.dataset_id));
@@ -258,14 +256,7 @@ class DatasetManagementTableComponent extends React.Component {
       ["Load", LoadStatusCell, { sortKey: "loading" }],
       ["Info", DatasetInfoCell, { sortable: false }],
       ["Name", (d) => d.name || d.dataset_id, { sortKey: "name" }],
-      [
-        "Source",
-        // `temporary: true` flags a user-uploaded dataset (Local).
-        // Everything else — server-ingested consolidated and legacy
-        // auspice manifest entries — labels as Server.
-        (d) => (d.temporary ? "Local" : "Server"),
-        { style: { fontSize: "12px" }, sortKey: "temporary" }
-      ],
+      ["Source", (d) => (isUserUpload(d) ? "Local" : "Server"), { style: { fontSize: "12px" }, sortKey: "source" }],
       ["Size (MB)", SizeCell, { sortKey: "file_size", style: { textAlign: "right" } }],
       ["Subjects", "subjects_count"],
       ["Families", "clone_count"],

--- a/src/components/tables/RowInfoModal.js
+++ b/src/components/tables/RowInfoModal.js
@@ -4,6 +4,7 @@
  */
 import React, { useState, useCallback } from "react";
 import { FiInfo, FiX, FiTrash2, FiCopy, FiChevronDown, FiChevronRight, FiCheck } from "react-icons/fi";
+import { isUserUpload } from "../../constants/datasetSource";
 
 /**
  * Formats a value for display in the modal
@@ -442,7 +443,10 @@ DatasetInfoCell.isReactComponent = true;
 
 /**
  * DatasetDeleteCell component
- * Delete button cell for dataset tables - only shows for client-side datasets
+ * Delete button cell for dataset tables — only shows for user-uploaded
+ * datasets. Server-ingested consolidated datasets and legacy split-format
+ * datasets re-ingest on the next page load, so deleting them from the UI
+ * would be misleading.
  */
 export function DatasetDeleteCell({ datum, onDelete }) {
   const [hovered, setHovered] = useState(false);
@@ -451,10 +455,7 @@ export function DatasetDeleteCell({ datum, onDelete }) {
     return <span>—</span>;
   }
 
-  const isClientSide = datum.isClientSide || datum.temporary;
-
-  // Don't show delete button for server-side datasets
-  if (!isClientSide) {
+  if (!isUserUpload(datum)) {
     return <div style={{ width: "100%", textAlign: "center" }}>—</div>;
   }
 
@@ -510,8 +511,7 @@ export function DatasetActionsCell({ datum, onDelete }) {
     return <span>—</span>;
   }
 
-  const isClientSide = datum.isClientSide || datum.temporary;
-  const showDelete = isClientSide && onDelete;
+  const showDelete = isUserUpload(datum) && onDelete;
 
   const handleInfoClick = (e) => {
     e.stopPropagation();

--- a/src/constants/__tests__/datasetSource.test.js
+++ b/src/constants/__tests__/datasetSource.test.js
@@ -1,0 +1,51 @@
+import { DATASET_SOURCE, sourceOf, isDatasetInIndexedDB, isUserUpload } from "../datasetSource";
+
+describe("sourceOf", () => {
+  it("prefers an explicit `source` field over derivation", () => {
+    expect(sourceOf({ source: DATASET_SOURCE.SERVER_CONSOLIDATED, temporary: true, isClientSide: true })).toBe(
+      DATASET_SOURCE.SERVER_CONSOLIDATED
+    );
+  });
+
+  it("derives UPLOAD from temporary + isClientSide both true (legacy upload record)", () => {
+    expect(sourceOf({ temporary: true, isClientSide: true })).toBe(DATASET_SOURCE.UPLOAD);
+  });
+
+  it("derives SERVER_CONSOLIDATED from isClientSide alone (legacy server-ingested record)", () => {
+    expect(sourceOf({ temporary: false, isClientSide: true })).toBe(DATASET_SOURCE.SERVER_CONSOLIDATED);
+  });
+
+  it("derives SERVER_SPLIT from neither flag set (legacy auspice manifest entry)", () => {
+    expect(sourceOf({ isClientSide: false })).toBe(DATASET_SOURCE.SERVER_SPLIT);
+    expect(sourceOf({})).toBe(DATASET_SOURCE.SERVER_SPLIT);
+  });
+
+  it("returns SERVER_SPLIT for null/undefined inputs (defensive)", () => {
+    expect(sourceOf(null)).toBe(DATASET_SOURCE.SERVER_SPLIT);
+    expect(sourceOf(undefined)).toBe(DATASET_SOURCE.SERVER_SPLIT);
+  });
+});
+
+describe("isDatasetInIndexedDB", () => {
+  it("returns true for UPLOAD and SERVER_CONSOLIDATED", () => {
+    expect(isDatasetInIndexedDB({ source: DATASET_SOURCE.UPLOAD })).toBe(true);
+    expect(isDatasetInIndexedDB({ source: DATASET_SOURCE.SERVER_CONSOLIDATED })).toBe(true);
+  });
+
+  it("returns false for SERVER_SPLIT (lives on the server, not in IndexedDB)", () => {
+    expect(isDatasetInIndexedDB({ source: DATASET_SOURCE.SERVER_SPLIT })).toBe(false);
+  });
+});
+
+describe("isUserUpload", () => {
+  it("returns true only for UPLOAD-sourced datasets", () => {
+    expect(isUserUpload({ source: DATASET_SOURCE.UPLOAD })).toBe(true);
+    expect(isUserUpload({ source: DATASET_SOURCE.SERVER_CONSOLIDATED })).toBe(false);
+    expect(isUserUpload({ source: DATASET_SOURCE.SERVER_SPLIT })).toBe(false);
+  });
+
+  it("derives correctly from legacy flags (record from before the enum landed)", () => {
+    expect(isUserUpload({ temporary: true, isClientSide: true })).toBe(true);
+    expect(isUserUpload({ temporary: false, isClientSide: true })).toBe(false);
+  });
+});

--- a/src/constants/datasetSource.js
+++ b/src/constants/datasetSource.js
@@ -1,0 +1,69 @@
+/**
+ * Where a dataset originated. Drives both UI labeling (the Source
+ * column) and loader routing (which fetch path to use for clones and
+ * trees).
+ *
+ * Previously this distinction was encoded across two boolean fields
+ * (`temporary` and `isClientSide`) whose combinations had to be read
+ * carefully — `(temporary: true, isClientSide: true)` meant "user
+ * upload", `(temporary: false, isClientSide: true)` meant
+ * "server-ingested consolidated", and `(temporary: undefined,
+ * isClientSide: false)` meant "legacy split-format manifest entry".
+ *
+ * The enum is now the load-bearing field. The legacy booleans are
+ * preserved (and still set) so that already-persisted IndexedDB
+ * records keep working without a schema migration — `sourceOf()`
+ * below derives the source from them when an explicit `source` field
+ * isn't present.
+ */
+export const DATASET_SOURCE = {
+  /** Uploaded by the user via the splash page. Lives in IndexedDB. */
+  UPLOAD: "upload",
+  /**
+   * Loaded from the server-side `/data/<consolidated_path>.json`
+   * during page bootstrap and ingested into IndexedDB. The wire format
+   * is an olmsted-cli consolidated JSON (or .json.gz).
+   */
+  SERVER_CONSOLIDATED: "server-consolidated",
+  /**
+   * Legacy auspice-shaped server-side dataset: a manifest entry in
+   * `/data/datasets.json` with per-clone and per-tree files served
+   * lazily from `/data/clones.{id}.json` and `/data/tree.{ident}.json`.
+   * Does not live in IndexedDB.
+   */
+  SERVER_SPLIT: "server-split"
+};
+
+/**
+ * Resolve a dataset's source. Prefers the explicit `source` field
+ * when present; otherwise derives from the legacy `temporary` /
+ * `isClientSide` flag combination so existing IndexedDB records and
+ * existing manifest entries continue to work.
+ *
+ * @param {Object} dataset
+ * @returns {string} one of DATASET_SOURCE.*
+ */
+export const sourceOf = (dataset) => {
+  if (!dataset) return DATASET_SOURCE.SERVER_SPLIT;
+  if (dataset.source) return dataset.source;
+  if (dataset.isClientSide && dataset.temporary) return DATASET_SOURCE.UPLOAD;
+  if (dataset.isClientSide) return DATASET_SOURCE.SERVER_CONSOLIDATED;
+  return DATASET_SOURCE.SERVER_SPLIT;
+};
+
+/**
+ * Datasets backed by IndexedDB use the client loader. Server-split
+ * datasets fall through to the legacy auspice fetch flow.
+ *
+ * @param {Object} dataset
+ * @returns {boolean}
+ */
+export const isDatasetInIndexedDB = (dataset) => sourceOf(dataset) !== DATASET_SOURCE.SERVER_SPLIT;
+
+/**
+ * Whether the dataset should label as "Local" in the UI Source column.
+ *
+ * @param {Object} dataset
+ * @returns {boolean}
+ */
+export const isUserUpload = (dataset) => sourceOf(dataset) === DATASET_SOURCE.UPLOAD;

--- a/src/server/__tests__/__fixtures__/server-data/clones.fixture-dataset-001.json
+++ b/src/server/__tests__/__fixtures__/server-data/clones.fixture-dataset-001.json
@@ -1,0 +1,16 @@
+[
+  {
+    "clone_id": "fixture-clone-001",
+    "dataset_id": "fixture-dataset-001",
+    "ident": "fixture-clone-001",
+    "trees": [
+      {
+        "ident": "fixture-tree-001",
+        "tree_id": "min_adcl-raxml_ng",
+        "clone_id": "fixture-clone-001",
+        "type": "cft.reconstruction",
+        "downsampling_strategy": "min_adcl"
+      }
+    ]
+  }
+]

--- a/src/server/__tests__/__fixtures__/server-data/consolidated.fixture-consolidated-001.json
+++ b/src/server/__tests__/__fixtures__/server-data/consolidated.fixture-consolidated-001.json
@@ -1,0 +1,60 @@
+{
+  "metadata": {
+    "schema_version": "2.0.0",
+    "name": "Fixture consolidated dataset",
+    "source_format": "pcp"
+  },
+  "datasets": [
+    {
+      "ident": "fixture-consolidated-ident-001",
+      "dataset_id": "fixture-consolidated-001",
+      "clone_count": 1,
+      "subjects_count": 1,
+      "timepoints_count": 1,
+      "schema_version": "2.0.0",
+      "name": "Fixture consolidated dataset"
+    }
+  ],
+  "clones": {
+    "fixture-consolidated-001": [
+      {
+        "clone_id": "fixture-consolidated-clone-001",
+        "ident": "fixture-consolidated-clone-001",
+        "dataset_id": "fixture-consolidated-001",
+        "v_call": "IGHV1-2*02",
+        "sample": { "locus": "IGH", "subject_id": "subject-1" }
+      }
+    ]
+  },
+  "trees": [
+    {
+      "ident": "fixture-consolidated-tree-001",
+      "tree_id": "min_adcl-raxml_ng",
+      "clone_id": "fixture-consolidated-clone-001",
+      "newick": "(A:1,B:1)naive:0;",
+      "nodes": [
+        {
+          "sequence_id": "naive",
+          "type": "root",
+          "parent": null,
+          "sequence_alignment": "AAA",
+          "sequence_alignment_aa": "K"
+        },
+        {
+          "sequence_id": "A",
+          "type": "leaf",
+          "parent": "naive",
+          "sequence_alignment": "AAG",
+          "sequence_alignment_aa": "K"
+        },
+        {
+          "sequence_id": "B",
+          "type": "leaf",
+          "parent": "naive",
+          "sequence_alignment": "AAA",
+          "sequence_alignment_aa": "K"
+        }
+      ]
+    }
+  ]
+}

--- a/src/server/__tests__/__fixtures__/server-data/datasets.json
+++ b/src/server/__tests__/__fixtures__/server-data/datasets.json
@@ -7,5 +7,15 @@
     "timepoints_count": 1,
     "schema_version": "2.0.0",
     "name": "Fixture dataset"
+  },
+  {
+    "ident": "fixture-consolidated-ident-001",
+    "dataset_id": "fixture-consolidated-001",
+    "clone_count": 1,
+    "subjects_count": 1,
+    "timepoints_count": 1,
+    "schema_version": "2.0.0",
+    "name": "Fixture consolidated dataset",
+    "consolidated_path": "consolidated.fixture-consolidated-001.json"
   }
 ]

--- a/src/server/__tests__/__fixtures__/server-data/datasets.json
+++ b/src/server/__tests__/__fixtures__/server-data/datasets.json
@@ -1,0 +1,11 @@
+[
+  {
+    "ident": "fixture-ident-001",
+    "dataset_id": "fixture-dataset-001",
+    "clone_count": 1,
+    "subjects_count": 1,
+    "timepoints_count": 1,
+    "schema_version": "2.0.0",
+    "name": "Fixture dataset"
+  }
+]

--- a/src/server/__tests__/__fixtures__/server-data/tree.fixture-tree-001.json
+++ b/src/server/__tests__/__fixtures__/server-data/tree.fixture-tree-001.json
@@ -1,0 +1,11 @@
+{
+  "ident": "fixture-tree-001",
+  "tree_id": "min_adcl-raxml_ng",
+  "clone_id": "fixture-clone-001",
+  "newick": "(A:1,B:1)naive:0;",
+  "nodes": {
+    "naive": { "type": "root", "parent": null },
+    "A": { "type": "leaf", "parent": "naive" },
+    "B": { "type": "leaf", "parent": "naive" }
+  }
+}

--- a/src/server/__tests__/charon.test.js
+++ b/src/server/__tests__/charon.test.js
@@ -1,0 +1,105 @@
+/**
+ * Route-level tests for src/server/charon.js
+ *
+ * The charon module wires `/charon/*` requests to the appropriate
+ * getFiles handler based on the `request` query parameter. We capture
+ * the handler registered with the mock Express app and invoke it
+ * directly with various query strings.
+ */
+
+jest.mock("../getFiles", () => ({
+  getDatasets: jest.fn(async () => {}),
+  getClonalFamilies: jest.fn(async () => {}),
+  getSplashImage: jest.fn(async () => {}),
+  getDatasetJson: jest.fn(async () => {})
+}));
+
+const getFiles = require("../getFiles");
+const charon = require("../charon");
+
+const makeRes = () => ({
+  status: jest.fn().mockReturnThis(),
+  send: jest.fn(),
+  headersSent: false
+});
+
+// Capture the handler registered for the /charon route.
+const captureHandler = () => {
+  let handler;
+  charon.applyCharonToApp({
+    get: (_path, fn) => {
+      handler = fn;
+    }
+  });
+  return handler;
+};
+
+describe("charon route", () => {
+  let handler;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    handler = captureHandler();
+  });
+
+  it.each([
+    ["datasets", "getDatasets"],
+    ["clonalFamilies", "getClonalFamilies"],
+    ["splashimage", "getSplashImage"],
+    ["json", "getDatasetJson"]
+  ])("dispatches request=%s to %s", async (request, handlerName) => {
+    const res = makeRes();
+    await handler({ originalUrl: `/charon?request=${request}`, url: `/charon?request=${request}` }, res);
+    expect(getFiles[handlerName]).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes the parsed query through to the handler", async () => {
+    const res = makeRes();
+    const url = "/charon?request=json&path=clones.fixture-dataset-001.json&s3=staging";
+    await handler({ originalUrl: url, url }, res);
+    expect(getFiles.getDatasetJson).toHaveBeenCalledWith(
+      expect.objectContaining({
+        request: "json",
+        path: "clones.fixture-dataset-001.json",
+        s3: "staging"
+      }),
+      res
+    );
+  });
+
+  it("silently ignores requests with no `request` query param", async () => {
+    const res = makeRes();
+    await handler({ originalUrl: "/charon", url: "/charon" }, res);
+    expect(getFiles.getDatasets).not.toHaveBeenCalled();
+    expect(getFiles.getClonalFamilies).not.toHaveBeenCalled();
+    expect(getFiles.getSplashImage).not.toHaveBeenCalled();
+    expect(getFiles.getDatasetJson).not.toHaveBeenCalled();
+  });
+
+  it("silently ignores requests with an unknown `request` value", async () => {
+    const res = makeRes();
+    await handler({ originalUrl: "/charon?request=unknown", url: "/charon?request=unknown" }, res);
+    expect(getFiles.getDatasets).not.toHaveBeenCalled();
+    expect(getFiles.getClonalFamilies).not.toHaveBeenCalled();
+  });
+
+  it("returns 500 when the handler throws and headers haven't been sent", async () => {
+    getFiles.getDatasets.mockImplementationOnce(async () => {
+      throw new Error("oops");
+    });
+    const res = makeRes();
+    await handler({ originalUrl: "/charon?request=datasets", url: "/charon?request=datasets" }, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith("Internal server error");
+  });
+
+  it("does not double-send when the handler throws after headers were sent", async () => {
+    getFiles.getDatasets.mockImplementationOnce(async () => {
+      throw new Error("oops");
+    });
+    const res = { ...makeRes(), headersSent: true };
+    await handler({ originalUrl: "/charon?request=datasets", url: "/charon?request=datasets" }, res);
+    expect(res.status).not.toHaveBeenCalled();
+    expect(res.send).not.toHaveBeenCalled();
+  });
+});

--- a/src/server/__tests__/getFiles.test.js
+++ b/src/server/__tests__/getFiles.test.js
@@ -53,6 +53,15 @@ describe("getFiles (local mode)", () => {
     await getFiles.getDatasetJson({ path: "clones.fixture-dataset-001.json" }, res);
     expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "clones.fixture-dataset-001.json"));
   });
+
+  it("getDatasetJson serves a consolidated olmsted-cli file as a plain path", async () => {
+    // The Charon API doesn't care about file format — it serves whatever
+    // file you point at. This is the wire-level prerequisite for the
+    // consolidated-server-dataset flow.
+    const res = makeRes();
+    await getFiles.getDatasetJson({ path: "consolidated.fixture-consolidated-001.json" }, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "consolidated.fixture-consolidated-001.json"));
+  });
 });
 
 describe("getFiles path validation", () => {

--- a/src/server/__tests__/getFiles.test.js
+++ b/src/server/__tests__/getFiles.test.js
@@ -1,0 +1,142 @@
+/**
+ * Unit tests for src/server/getFiles.js
+ *
+ * Covers the file-serving layer used by the Charon API:
+ * - validateFilePath rejects traversal and absolute paths (tested
+ *   indirectly through getSplashImage / getDatasetJson, which surface
+ *   the validation errors).
+ * - getDataFile dispatches to res.sendFile for LOCAL_DATA mode and
+ *   to remote fetch for staging/live S3 modes.
+ *
+ * Remote fetch paths are tested by mocking globalThis.fetch.
+ */
+
+const path = require("path");
+const getFiles = require("../getFiles");
+const globals = require("../globals");
+
+const FIXTURE_DIR = path.resolve(__dirname, "__fixtures__/server-data");
+
+const makeRes = () => ({
+  sendFile: jest.fn(),
+  send: jest.fn(),
+  set: jest.fn(),
+  status: jest.fn().mockReturnThis(),
+  headersSent: false
+});
+
+describe("getFiles (local mode)", () => {
+  beforeEach(() => {
+    globals.setGlobals({ localData: true, localDataPath: FIXTURE_DIR });
+  });
+
+  it("getDatasets serves datasets.json from the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "datasets.json"));
+  });
+
+  it("getClonalFamilies serves clones.json from the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getClonalFamilies({}, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "clones.json"));
+  });
+
+  it("getSplashImage serves the requested src under the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getSplashImage({ src: "splash.svg" }, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "splash.svg"));
+  });
+
+  it("getDatasetJson serves the requested path under the local data dir", async () => {
+    const res = makeRes();
+    await getFiles.getDatasetJson({ path: "clones.fixture-dataset-001.json" }, res);
+    expect(res.sendFile).toHaveBeenCalledWith(path.join(FIXTURE_DIR, "clones.fixture-dataset-001.json"));
+  });
+});
+
+describe("getFiles path validation", () => {
+  beforeEach(() => {
+    globals.setGlobals({ localData: true, localDataPath: FIXTURE_DIR });
+  });
+
+  it.each([
+    ["traversal sequence", { src: "../etc/passwd" }],
+    ["backslash", { src: "foo\\bar" }],
+    ["absolute path", { src: "/etc/passwd" }],
+    ["empty path", { src: "" }]
+  ])("getSplashImage rejects %s with 400", async (_label, query) => {
+    const res = makeRes();
+    await getFiles.getSplashImage(query, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Invalid request:/));
+    expect(res.sendFile).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["traversal sequence", { path: "../../secret.json" }],
+    ["absolute path", { path: "/tmp/leak.json" }],
+    ["empty path", {}]
+  ])("getDatasetJson rejects %s with 400", async (_label, query) => {
+    const res = makeRes();
+    await getFiles.getDatasetJson(query, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Invalid request:/));
+    expect(res.sendFile).not.toHaveBeenCalled();
+  });
+});
+
+describe("getFiles (remote mode)", () => {
+  let originalFetch;
+
+  beforeEach(() => {
+    globals.setGlobals({ localData: false });
+    originalFetch = globalThis.fetch;
+    // Each test installs its own fetch mock that returns a small payload.
+    globalThis.fetch = jest.fn(async () => ({
+      ok: true,
+      headers: { get: () => "application/json" },
+      arrayBuffer: async () => new ArrayBuffer(0)
+    }));
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("getDatasets fetches from the live S3 base URL by default", async () => {
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(globalThis.fetch).toHaveBeenCalledWith(`${global.REMOTE_DATA_LIVE_BASEURL}datasets.json`);
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it("getDatasets honors s3=staging by fetching from the staging base URL", async () => {
+    const res = makeRes();
+    await getFiles.getDatasets({ s3: "staging" }, res);
+    expect(globalThis.fetch).toHaveBeenCalledWith(`${global.REMOTE_DATA_STAGING_BASEURL}datasets.json`);
+  });
+
+  it("propagates non-OK status codes from the remote", async () => {
+    globalThis.fetch = jest.fn(async () => ({
+      ok: false,
+      status: 404,
+      statusText: "Not Found",
+      headers: { get: () => "text/html" }
+    }));
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Failed to fetch/));
+  });
+
+  it("returns 500 when the remote fetch throws", async () => {
+    globalThis.fetch = jest.fn(async () => {
+      throw new Error("network down");
+    });
+    const res = makeRes();
+    await getFiles.getDatasets({}, res);
+    expect(res.status).toHaveBeenCalledWith(500);
+    expect(res.send).toHaveBeenCalledWith(expect.stringMatching(/Failed to fetch/));
+  });
+});

--- a/src/utils/fileProcessor.js
+++ b/src/utils/fileProcessor.js
@@ -1,6 +1,7 @@
 import { gunzipSync, strFromU8 } from "fflate";
 import { detectFieldPresence, applyNodeDefaults, applyCloneDefaults, extractGermlineFromTree } from "./fieldDefaults";
 import { NODE_TYPES, LEGACY_INTERNAL_NODE_TYPE } from "../constants/nodeTypes";
+import { DATASET_SOURCE } from "../constants/datasetSource";
 
 /**
  * File processor for olmsted-cli consolidated format JSON files
@@ -94,6 +95,10 @@ class FileProcessor {
       clone_count: datasetClones.length || dataset.clone_count || 0,
       subjects_count: dataset.subjects_count || 1,
       schema_version: data.metadata?.schema_version || null,
+      // `source` is the load-bearing field for Source labeling and loader
+      // routing. The legacy booleans are preserved for code that hasn't
+      // been migrated yet and for already-persisted IndexedDB records.
+      source: DATASET_SOURCE.UPLOAD,
       temporary: true,
       isClientSide: true,
       upload_time: new Date().toISOString(),


### PR DESCRIPTION
## Summary

Four pieces of "server-side dataset" infrastructure work, toward closing #293 (legacy server-side cleanup):

1. **Consolidated format support** on the server-side data path. Until now, the static `/data/` flow only handled the auspice-shaped split format (one manifest + per-dataset clones files + per-tree files). This adds end-to-end support for serving olmsted-cli consolidated `.json` / `.json.gz` files alongside the split format, so the new olmsted-CLI-generated datasets can ship before split is removed in #292.
2. **Test coverage** for the Charon API (`src/server/charon.js` → `src/server/getFiles.js`) and for the new consolidated ingestion path in `src/actions/clientDataLoader.js`.
3. **Documentation** of the local-data workflow (`DEVELOPMENT.md`), covering both formats.
4. **Operational tooling**: `bin/snapshot_server_data.py` for producing a local mirror of the production datasets, and `bin/aws_delete.py` to drive the eventual deletion of the legacy datasets from S3.

## What's in this PR

### Consolidated server-side support

`/data/datasets.json` manifest entries gain an optional `consolidated_path` field pointing at an olmsted-cli `.json` or `.json.gz` file under the data root:

```jsonc
{
  "dataset_id": "my-dataset",
  "consolidated_path": "consolidated/my-dataset.json.gz"
}
```

On page load, `clientDataLoader.ingestConsolidatedServerDatasets` fetches each such file, wraps the response in a `File`, and runs it through `FileProcessor.processFile` (the same code path uploads use). Stored in IndexedDB; subsequent loads short-circuit via `olmstedDB.findDatasetByOriginalId`. Entries without `consolidated_path` continue through the legacy split-format flow unchanged.

Failure modes are non-fatal: a bad fetch, an invalid payload, or an unparseable manifest all log a warning and skip the entry; other datasets continue to load.

### Tests (32 new across 3 suites)

- **`src/server/__tests__/getFiles.test.js`** (16 tests):
  - Local-mode dispatch: `getDatasets`/`getClonalFamilies`/`getSplashImage`/`getDatasetJson` all resolve under `LOCAL_DATA_PATH`, including a consolidated file path.
  - Path validation: traversal, backslashes, absolute paths, and empty paths rejected with 400.
  - Remote-mode dispatch with mocked `globalThis.fetch`: live vs. staging base URL, non-OK status propagation, fetch-throws → 500.
- **`src/server/__tests__/charon.test.js`** (9 tests):
  - Route dispatch maps each `request=…` value to the correct handler.
  - Query passthrough, unknown/missing rejection, throw → 500 with `headersSent` guard.
- **`src/actions/__tests__/clientDataLoader.test.js`** (7 tests, new file):
  - Fetch + ingest round-trip writes to IndexedDB.
  - Short-circuit on second call (`findDatasetByOriginalId` dedupe).
  - Graceful handling of 404, non-JSON payloads, non-array manifests.

### Fixtures

`src/server/__tests__/__fixtures__/server-data/` — a minimal 4-file tree (split-style 1 dataset / 1 clone / 1 tree, plus 1 consolidated payload referenced from the manifest).

### Documentation

`DEVELOPMENT.md` "With Local Data (Server Mode)" section rewritten:

- Documents the `/data/*` file layout for both formats.
- Explains the `consolidated_path` manifest field and the fetch-as-upload ingestion model.
- Distinguishes from the upload-time format (which is the same wire shape).

### Operational tooling

- **`bin/snapshot_server_data.py`** — fetches the current production manifest from `http://www.olmstedviz.org/data/` and downloads every referenced file into `_data/server-snapshot/` (~780 MB). Useful for offline dev and for snapshotting before deletion.
- **`bin/aws_delete.py`** — general-purpose S3 deletion script mirroring `bin/aws_download.py` conventions:
  - `-b/--bucket`, `-p/--prefix`, `-s/--search` (+ `-r/--regex`), `-c/--creds`, `--anonymous`, `--list-only`
  - `--dry-run` is the default; `--confirm` must be passed to actually delete
  - Always prints count + total size + a head/tail sample of keys before deletion
  - DeleteObjects is batched at the S3 limit (1000 keys/call) with per-batch progress

## Test plan

- [x] `npm test` — 640 tests across 32 suites, all passing
- [x] `npx prettier --check` and `npx eslint` on touched files — clean
- [x] `python3 -m py_compile bin/aws_delete.py bin/snapshot_server_data.py` — clean
- [x] Manual QA: `npm run start:local _data/server-snapshot/` — all 3 legacy split-format datasets load, families/trees/lineage render
- [ ] Manual QA: drop an olmsted-cli consolidated dataset into a local snapshot dir, extend the manifest with `consolidated_path`, verify it ingests on page load and shows in the datasets list alongside the split-format ones
- [ ] Manual QA: `bin/aws_delete.py -b www.olmstedviz.org -p data/ --list-only` matches the expected file count of the snapshot

## Out of scope

- Removing the dead `data.nextstrain.org` URL in `src/server/globals.js:6` — covered by #293's client-side cleanup section.
- Sunsetting split-style upload — #292.
- Executing the deletion against production S3 — done manually after this lands.

## Continuation of

Closed PR #291 (branch was renamed via GitHub's rename API, which doesn't preserve PR associations).

🤖 Generated with [Claude Code](https://claude.com/claude-code)