### PR TITLE
Batch dependency bumps (supersedes 7 dependabot PRs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## version 2.7.4 - 2026/05/22
+Changed:
+* Dependency bumps (supersedes dependabot PRs #275, #276, #284, #288, #289, #290, #295): uuid 13 → 14, webpack-dev-server 5.2.3 → 5.2.4, postcss 8.5.8 → 8.5.15, fast-uri 3.1.0 → 3.1.2, @xmldom/xmldom 0.8.12 → 0.8.13, ip-address 10.1.0 → 10.2.0, @babel/plugin-transform-modules-systemjs 7.29.0 → 7.29.4. All patch/minor except uuid (major, but uuid isn't imported anywhere in `src/` — the bump is effectively a lockfile-only change).
+
 ## version 2.7.3 - 2026/05/20
 Changed:
 * Removed the legacy auspice-shaped server dataset path (closes #293). Deleted `src/actions/loadData.js`, `src/util/parseParams.js`, `src/actions/recomputeReduxState.js`, the `/charon/*` Express route, `src/server/getFiles.js`, and the remote-mode S3 globals. Server-side datasets are now exclusively the consolidated olmsted-cli format ingested into IndexedDB on page load.

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "redux-thunk": "^3.1.0",
         "reselect": "^5.1.1",
         "terser-webpack-plugin": "^5.4.0",
-        "uuid": "^13.0.0",
+        "uuid": "^14.0.0",
         "vega": "^6.2.0",
         "vega-embed": "^7.1.0",
         "vega-lite": "^6.4.2",
@@ -100,7 +100,7 @@
         "rimraf": "^5.0.7",
         "style-loader": "^4.0.0",
         "webpack-cli": "^7.0.2",
-        "webpack-dev-server": "^5.2.3",
+        "webpack-dev-server": "^5.2.4",
         "webpack-hot-middleware": "^2.26.1",
         "webpack-shell-plugin": "^0.5.0"
       },
@@ -1467,9 +1467,9 @@
       }
     },
     "node_modules/@babel/plugin-transform-modules-systemjs": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.0.tgz",
-      "integrity": "sha512-PrujnVFbOdUpw4UHiVwKvKRLMMic8+eC0CuNlxjsyZUiBjhFdPsewdXCkveh2KqBA9/waD0W1b4hXSOBQJezpQ==",
+      "version": "7.29.4",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-modules-systemjs/-/plugin-transform-modules-systemjs-7.29.4.tgz",
+      "integrity": "sha512-N7QmZ0xRZfjHOfZeQLJjwgX2zS9pdGHSVl/cjSGlo4dXMqvurfxXDMKY4RqEKzPozV78VMcd0lxyG13mlbKc4w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5701,9 +5701,9 @@
       }
     },
     "node_modules/@xmldom/xmldom": {
-      "version": "0.8.12",
-      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.12.tgz",
-      "integrity": "sha512-9k/gHF6n/pAi/9tqr3m3aqkuiNosYTurLLUtc7xQ9sxB/wm7WPygCv8GYa6mS0fLJEHhqMC1ATYhz++U/lRHqg==",
+      "version": "0.8.13",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.8.13.tgz",
+      "integrity": "sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -10224,9 +10224,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",
@@ -11710,9 +11710,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -14558,9 +14558,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -15622,9 +15622,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -15642,7 +15642,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -18775,9 +18775,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "13.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-13.0.0.tgz",
-      "integrity": "sha512-XQegIaBTVUjSHliKqcnFqYypAd4S+WCYt5NIeRs6w/UAry7z8Y9j5ZwRRL4kzq9U3sD6v+85er9FvkEaBpji2w==",
+      "version": "14.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-14.0.0.tgz",
+      "integrity": "sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"
@@ -19633,9 +19633,9 @@
       }
     },
     "node_modules/webpack-dev-server": {
-      "version": "5.2.3",
-      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.3.tgz",
-      "integrity": "sha512-9Gyu2F7+bg4Vv+pjbovuYDhHX+mqdqITykfzdM9UyKqKHlsE5aAjRhR+oOEfXW5vBeu8tarzlJFIZva4ZjAdrQ==",
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-5.2.4.tgz",
+      "integrity": "sha512-GqDPGZN9bRqKBTkp4aWkobDDHMsrXKoGSdOH56smIri8qR0JG8gfL8/v/f/OZR3/OKXjG8uwJbFVhKm/FNU/UA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
     "redux-thunk": "^3.1.0",
     "reselect": "^5.1.1",
     "terser-webpack-plugin": "^5.4.0",
-    "uuid": "^13.0.0",
+    "uuid": "^14.0.0",
     "vega": "^6.2.0",
     "vega-embed": "^7.1.0",
     "vega-lite": "^6.4.2",
@@ -125,7 +125,7 @@
     "rimraf": "^5.0.7",
     "style-loader": "^4.0.0",
     "webpack-cli": "^7.0.2",
-    "webpack-dev-server": "^5.2.3",
+    "webpack-dev-server": "^5.2.4",
     "webpack-hot-middleware": "^2.26.1",
     "webpack-shell-plugin": "^0.5.0"
   },


### PR DESCRIPTION
## Summary

Combines all 7 currently-open dependabot bumps into a single batch. All are patch or minor except uuid (major, but uuid isn't imported anywhere in `src/` — the bump is effectively lockfile-only).

| Package | From | To | Type | Notes |
|---|---|---|---|---|
| uuid | 13.0.0 | 14.0.0 | major | Declared in package.json but no `import "uuid"` in src/ — vacuous |
| webpack-dev-server | 5.2.3 | 5.2.4 | patch | Direct devDep |
| postcss | 8.5.8 | 8.5.15 | patch | Transitive |
| fast-uri | 3.1.0 | 3.1.2 | patch | Transitive |
| @xmldom/xmldom | 0.8.12 | 0.8.13 | patch | Transitive |
| ip-address | 10.1.0 | 10.2.0 | minor | Transitive |
| @babel/plugin-transform-modules-systemjs | 7.29.0 | 7.29.4 | patch | Transitive |

## Verification

- `npm run format:check` — clean
- `npm run lint` — 0 errors (39 pre-existing warnings unchanged)
- `npm test` — 645/645 tests pass across 32 suites
- `npm run build:client` — production bundle builds successfully

## Supersedes

Closes #275, #276, #284, #288, #289, #290, #295 once merged.

## Test plan

- [x] Local test suite passes
- [x] Production build succeeds
- [x] Manual smoke: `npm start` → splash loads → upload a consolidated .json.gz → renders
- [x] Manual smoke: dev server with `--hot` (webpack-dev-server 5.2.4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)