### PR TITLE
Reconcile cached server datasets with live manifest on load (#301)

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -611,6 +611,15 @@ The application uses Dexie.js to manage IndexedDB storage with the following sch
 
 This lazy loading approach enables handling datasets with thousands of clonal families while maintaining responsive UI performance.
 
+#### Server-side dataset lifecycle
+
+Each persisted dataset record carries a `source` field (see `src/constants/datasetSource.js`):
+
+- **`SERVER_CONSOLIDATED`** — ingested from `/data/datasets.json` at page load. **Ephemeral**: reconciliation in `getClientDatasets` (`src/actions/clientDataLoader.js`) deletes any cached entry whose `original_dataset_id` is no longer in the manifest, and deletes any entry whose manifest `name` has changed so the ingest pass re-fetches it.
+- **`UPLOAD`** — user drag-and-drop. **Permanent**: never touched by reconciliation. Only `handleDatasetDelete` (the per-row Delete button) and `clearAll` can remove them.
+
+The reconciliation filter in `olmstedDB.getServerConsolidatedDatasets()` checks the raw `source` field, not `sourceOf()`'s legacy-flag fallback, so a pre-`source`-enum upload missing `temporary: true` won't be swept by accident.
+
 ---
 
 _Last updated: 2026-03-13_

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -350,20 +350,53 @@ describe("reconcileServerConsolidated", () => {
       source: "server-consolidated",
       temporary: false
     });
-    // Seed a clone so the orphan-check sees clones-without-trees.
+    // Seed a clone with trees_meta populated, so the orphan-check sees
+    // "trees were expected, but the trees table has none" — the
+    // legacy-cascade-damage signature.
     await olmstedDB.clones.put({
       dataset_id: "upload-survivor",
       clone_id: "clone-1",
       sample_id: "s1",
       name: "Clone 1",
       unique_seqs_count: 1,
-      mean_mut_freq: 0
+      mean_mut_freq: 0,
+      trees_meta: [{ ident: "wiped-tree-ident", tree_id: "t-1", name: "tree" }]
     });
 
     await reconcileServerConsolidated([{ dataset_id: "wiped-001", name: "Wiped Trees Dataset" }]);
 
     const all = await olmstedDB.getAllDatasets();
     expect(all).toHaveLength(0);
+  });
+
+  it("treats datasets with no trees_meta on any clone as legitimately tree-free, not orphaned", async () => {
+    // Some olmsted-cli outputs skip tree-building for every family in a
+    // dataset (the "0 root nodes (expected 1). Skipping this tree." path).
+    // Those datasets land in IndexedDB with clones but no trees AND with
+    // every clone's trees_meta empty. The heal MUST NOT fire on them or
+    // it would force-refetch on every page load.
+    await seed({
+      dataset_id: "upload-tree-free",
+      original_dataset_id: "tree-free-001",
+      name: "Legitimately Tree-Free",
+      source: "server-consolidated",
+      temporary: false
+    });
+    await olmstedDB.clones.put({
+      dataset_id: "upload-tree-free",
+      clone_id: "clone-1",
+      sample_id: "s1",
+      name: "Clone 1",
+      unique_seqs_count: 1,
+      mean_mut_freq: 0,
+      trees_meta: [] // no trees ever expected
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "tree-free-001", name: "Legitimately Tree-Free" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].dataset_id).toBe("upload-tree-free");
   });
 
   it("leaves intact datasets alone (clones + trees both present)", async () => {
@@ -456,5 +489,39 @@ describe("getClientDatasets manifest reconciliation", () => {
     const all = await olmstedDB.getAllDatasets();
     expect(all).toHaveLength(1);
     expect(all[0].original_dataset_id).toBe("would-be-stale-001");
+  });
+
+  it("does not fire the orphan-trees heal when the manifest fetch fails", async () => {
+    // Defense-in-depth: a transient outage must not trigger the recovery
+    // path. Seed a dataset that LOOKS orphan-tree-shaped (clones with
+    // trees_meta, no trees) but make the manifest fetch fail; reconcile
+    // is skipped entirely and the row survives.
+    await olmstedDB.datasets.put({
+      dataset_id: "upload-would-be-healed",
+      original_dataset_id: "would-be-healed-001",
+      name: "Pseudo-Orphan Dataset",
+      source: "server-consolidated",
+      temporary: false,
+      isClientSide: true
+    });
+    await olmstedDB.clones.put({
+      dataset_id: "upload-would-be-healed",
+      clone_id: "clone-1",
+      sample_id: "s1",
+      name: "Clone 1",
+      unique_seqs_count: 1,
+      mean_mut_freq: 0,
+      trees_meta: [{ ident: "would-be-tree", tree_id: "t-1", name: "tree" }]
+    });
+
+    globalThis.fetch = jest.fn(async () => mockResponse("", { ok: false, status: 500 }));
+    const dispatch = jest.fn();
+    await getClientDatasets(dispatch);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].dataset_id).toBe("upload-would-be-healed");
+    const clones = await olmstedDB.clones.where("dataset_id").equals("upload-would-be-healed").toArray();
+    expect(clones).toHaveLength(1);
   });
 });

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -338,6 +338,66 @@ describe("reconcileServerConsolidated", () => {
     expect(all[0].dataset_id).toBe("upload-100-aaa");
   });
 
+  it("heals datasets whose trees were wiped by the legacy removeDataset cascade", async () => {
+    // Recovery for users hit by the pre-fix cascade. The dataset row and
+    // its clones are intact, but the trees table has nothing under the
+    // namespaced prefix. Reconcile detects this and deletes the dataset
+    // so the ingest pass re-fetches it fresh.
+    await seed({
+      dataset_id: "upload-survivor",
+      original_dataset_id: "wiped-001",
+      name: "Wiped Trees Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+    // Seed a clone so the orphan-check sees clones-without-trees.
+    await olmstedDB.clones.put({
+      dataset_id: "upload-survivor",
+      clone_id: "clone-1",
+      sample_id: "s1",
+      name: "Clone 1",
+      unique_seqs_count: 1,
+      mean_mut_freq: 0
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "wiped-001", name: "Wiped Trees Dataset" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(0);
+  });
+
+  it("leaves intact datasets alone (clones + trees both present)", async () => {
+    // Negative case for the orphan-clones heal: a dataset with both
+    // clones and trees should not be deleted just because reconcile ran.
+    await seed({
+      dataset_id: "upload-healthy",
+      original_dataset_id: "healthy-001",
+      name: "Healthy Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+    await olmstedDB.clones.put({
+      dataset_id: "upload-healthy",
+      clone_id: "clone-1",
+      sample_id: "s1",
+      name: "Clone 1",
+      unique_seqs_count: 1,
+      mean_mut_freq: 0
+    });
+    await olmstedDB.trees.put({
+      ident: "upload-healthy::tree-1",
+      tree_id: "tree-1",
+      clone_id: "clone-1",
+      nodes: { naive: { type: "root" } }
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "healthy-001", name: "Healthy Dataset" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].dataset_id).toBe("upload-healthy");
+  });
+
   it("deduplicates and sweeps in the same pass", async () => {
     // Duplicates AND no-longer-in-manifest. Dedup runs first, then sweep
     // removes the survivor too.

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -135,6 +135,27 @@ describe("ingestConsolidatedServerDataset", () => {
     expect(stored).toBeNull();
     expect(await olmstedDB.datasets.count()).toBe(0);
   });
+
+  it("serializes concurrent ingest calls for the same dataset_id (no race)", async () => {
+    // Without the inflight gate, both ingests would pass `findDatasetByOriginalId`
+    // before either had written, then both would store, producing two rows
+    // with the same `original_dataset_id` (the production bug
+    // Monitor + App double-mount triggers).
+    const consolidatedText = readFixture("consolidated.fixture-consolidated-001.json");
+    globalThis.fetch = jest.fn(async () => mockResponse(consolidatedText));
+
+    const entry = {
+      dataset_id: "fixture-consolidated-001",
+      consolidated_path: "consolidated.fixture-consolidated-001.json"
+    };
+    const [a, b] = await Promise.all([ingestConsolidatedServerDataset(entry), ingestConsolidatedServerDataset(entry)]);
+
+    expect(globalThis.fetch).toHaveBeenCalledTimes(1);
+    expect(await olmstedDB.datasets.count()).toBe(1);
+    expect(a).toBeTruthy();
+    expect(b).toBeTruthy();
+    expect(a.dataset_id).toBe(b.dataset_id);
+  });
 });
 
 describe("ingestConsolidatedServerDatasets (manifest-driven)", () => {
@@ -281,6 +302,64 @@ describe("reconcileServerConsolidated", () => {
     const all = await olmstedDB.getAllDatasets();
     expect(all).toHaveLength(1);
     expect(all[0].name).toBe("Legacy Server Record");
+  });
+
+  it("deduplicates cached rows sharing an original_dataset_id, keeping the oldest", async () => {
+    // Race-induced duplicates: two rows with the same original_dataset_id
+    // but different storage dataset_ids (timestamp-prefixed by
+    // generateDatasetId). Reconcile keeps the lexicographically-smallest
+    // storage id (= oldest timestamp) and deletes the rest.
+    await seed({
+      dataset_id: "upload-100-aaa",
+      original_dataset_id: "dup-001",
+      name: "Duplicated Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+    await seed({
+      dataset_id: "upload-200-bbb",
+      original_dataset_id: "dup-001",
+      name: "Duplicated Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+    await seed({
+      dataset_id: "upload-300-ccc",
+      original_dataset_id: "dup-001",
+      name: "Duplicated Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "dup-001", name: "Duplicated Dataset" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].dataset_id).toBe("upload-100-aaa");
+  });
+
+  it("deduplicates and sweeps in the same pass", async () => {
+    // Duplicates AND no-longer-in-manifest. Dedup runs first, then sweep
+    // removes the survivor too.
+    await seed({
+      dataset_id: "upload-100-aaa",
+      original_dataset_id: "stale-dup-001",
+      name: "Stale Duplicated Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+    await seed({
+      dataset_id: "upload-200-bbb",
+      original_dataset_id: "stale-dup-001",
+      name: "Stale Duplicated Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+
+    await reconcileServerConsolidated([]); // empty manifest
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(0);
   });
 });
 

--- a/src/actions/__tests__/clientDataLoader.test.js
+++ b/src/actions/__tests__/clientDataLoader.test.js
@@ -17,7 +17,12 @@ jest.mock("../../util/globals", () => ({
   dataBaseURL: "/data"
 }));
 
-const { ingestConsolidatedServerDataset, ingestConsolidatedServerDatasets } = require("../clientDataLoader");
+const {
+  ingestConsolidatedServerDataset,
+  ingestConsolidatedServerDatasets,
+  reconcileServerConsolidated,
+  getClientDatasets
+} = require("../clientDataLoader");
 const olmstedDB = require("../../utils/olmstedDB").default;
 
 const FIXTURE_DIR = path.resolve(__dirname, "../../server/__tests__/__fixtures__/server-data");
@@ -176,5 +181,141 @@ describe("ingestConsolidatedServerDatasets (manifest-driven)", () => {
     await ingestConsolidatedServerDatasets();
     const all = await olmstedDB.getAllDatasets();
     expect(all).toHaveLength(0);
+  });
+});
+
+describe("reconcileServerConsolidated", () => {
+  beforeEach(async () => {
+    await olmstedDB.ready;
+    await olmstedDB.clearAll();
+  });
+
+  // Seed a dataset record directly, bypassing FileProcessor. Anything not
+  // overridden falls back to the storage-layer defaults the rest of the
+  // app expects on a real ingested record.
+  const seed = (props) =>
+    olmstedDB.datasets.put({
+      dataset_id: `local-${Math.random().toString(36).slice(2)}`,
+      isClientSide: true,
+      ...props
+    });
+
+  it("removes server-consolidated entries no longer present in the manifest", async () => {
+    await seed({
+      original_dataset_id: "stale-001",
+      name: "Stale Server Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+    await seed({
+      original_dataset_id: "live-001",
+      name: "Live Server Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "live-001", name: "Live Server Dataset" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].original_dataset_id).toBe("live-001");
+  });
+
+  it("removes server-consolidated entries whose manifest name has changed", async () => {
+    // Removal here is the intended trigger for re-ingestion: the subsequent
+    // ingest pass will fetch the file fresh because findDatasetByOriginalId
+    // no longer matches.
+    await seed({
+      original_dataset_id: "renamed-001",
+      name: "Old Name",
+      source: "server-consolidated",
+      temporary: false
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "renamed-001", name: "New Name" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(0);
+  });
+
+  it("leaves server-consolidated entries with matching name untouched", async () => {
+    await seed({
+      original_dataset_id: "stable-001",
+      name: "Stable Dataset",
+      source: "server-consolidated",
+      temporary: false
+    });
+
+    await reconcileServerConsolidated([{ dataset_id: "stable-001", name: "Stable Dataset" }]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("Stable Dataset");
+  });
+
+  it("never touches UPLOAD entries, even when absent from the manifest", async () => {
+    await seed({
+      original_dataset_id: "user-upload-001",
+      name: "User Upload",
+      source: "upload",
+      temporary: true
+    });
+
+    await reconcileServerConsolidated([]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].original_dataset_id).toBe("user-upload-001");
+  });
+
+  it("skips records missing original_dataset_id (legacy / malformed)", async () => {
+    await seed({
+      // no original_dataset_id
+      name: "Legacy Server Record",
+      source: "server-consolidated",
+      temporary: false
+    });
+
+    await reconcileServerConsolidated([]);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].name).toBe("Legacy Server Record");
+  });
+});
+
+describe("getClientDatasets manifest reconciliation", () => {
+  let originalFetch;
+
+  beforeEach(async () => {
+    originalFetch = globalThis.fetch;
+    await olmstedDB.ready;
+    await olmstedDB.clearAll();
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("does not delete cached datasets when the manifest fetch fails", async () => {
+    // Offline / 500 / CORS → manifest === null. Reconciliation must be
+    // skipped entirely; the cached entry survives so the user still has
+    // something to look at.
+    await olmstedDB.datasets.put({
+      dataset_id: "local-stale",
+      original_dataset_id: "would-be-stale-001",
+      name: "Cached Server Dataset",
+      source: "server-consolidated",
+      temporary: false,
+      isClientSide: true
+    });
+
+    globalThis.fetch = jest.fn(async () => mockResponse("", { ok: false, status: 500 }));
+    const dispatch = jest.fn();
+    await getClientDatasets(dispatch);
+
+    const all = await olmstedDB.getAllDatasets();
+    expect(all).toHaveLength(1);
+    expect(all[0].original_dataset_id).toBe("would-be-stale-001");
   });
 });

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -150,42 +150,70 @@ export const getClientClonalFamilies = async (dispatch, dataset_id) => {
 };
 
 /**
+ * In-flight ingest promises keyed by manifest `dataset_id` (which becomes
+ * the persisted `original_dataset_id`). Two concurrent callers ingesting
+ * the same entry share one fetch+store pass so we never race in front of
+ * `findDatasetByOriginalId` and write two rows for the same source dataset.
+ *
+ * This matters because `Monitor.componentDidMount` and
+ * `App.componentDidMount` both call `getClientDatasets` on initial mount
+ * — they fire close enough together that neither sees the other's writes
+ * before kicking off ingest.
+ */
+const inflightIngest = new Map();
+
+/**
  * Fetch a consolidated server-side dataset file (olmsted-cli JSON or .json.gz),
  * route it through the upload pipeline, and store in IndexedDB. Subsequent
- * calls for the same `original_dataset_id` short-circuit.
+ * calls for the same `original_dataset_id` short-circuit. Concurrent calls
+ * for the same id share one in-flight promise.
  *
  * @param {Object} entry - Manifest entry with consolidated_path + dataset_id
  * @returns {Promise<Object|null>} The stored dataset record, or null on failure
  */
 export const ingestConsolidatedServerDataset = async (entry) => {
-  try {
-    const existing = await olmstedDB.findDatasetByOriginalId(entry.dataset_id);
-    if (existing) return existing;
+  const existingInflight = inflightIngest.get(entry.dataset_id);
+  if (existingInflight) return existingInflight;
 
-    const url = `${dataBaseURL}/${entry.consolidated_path}`;
-    const response = await fetch(url);
-    if (!response.ok) {
-      console.warn(`Failed to fetch consolidated server dataset at ${url}: ${response.status} ${response.statusText}`);
+  const ingestPromise = (async () => {
+    try {
+      const existing = await olmstedDB.findDatasetByOriginalId(entry.dataset_id);
+      if (existing) return existing;
+
+      const url = `${dataBaseURL}/${entry.consolidated_path}`;
+      const response = await fetch(url);
+      if (!response.ok) {
+        console.warn(
+          `Failed to fetch consolidated server dataset at ${url}: ${response.status} ${response.statusText}`
+        );
+        return null;
+      }
+
+      const blob = await response.blob();
+      const filename = entry.consolidated_path.split("/").pop();
+      const file = new File([blob], filename, { type: blob.type });
+      const result = await FileProcessor.processFile(file);
+
+      // FileProcessor sets source = UPLOAD; override to SERVER_CONSOLIDATED.
+      // `temporary` is flipped to false so the Source column reads "Server".
+      if (result.datasets && result.datasets[0]) {
+        result.datasets[0].source = DATASET_SOURCE.SERVER_CONSOLIDATED;
+        result.datasets[0].temporary = false;
+      }
+
+      await clientDataStore.storeProcessedData(result);
+      return result.datasets[0];
+    } catch (error) {
+      console.warn(`Failed to ingest consolidated server dataset ${entry.dataset_id}:`, error);
       return null;
     }
+  })();
 
-    const blob = await response.blob();
-    const filename = entry.consolidated_path.split("/").pop();
-    const file = new File([blob], filename, { type: blob.type });
-    const result = await FileProcessor.processFile(file);
-
-    // FileProcessor sets source = UPLOAD; override to SERVER_CONSOLIDATED.
-    // `temporary` is flipped to false so the Source column reads "Server".
-    if (result.datasets && result.datasets[0]) {
-      result.datasets[0].source = DATASET_SOURCE.SERVER_CONSOLIDATED;
-      result.datasets[0].temporary = false;
-    }
-
-    await clientDataStore.storeProcessedData(result);
-    return result.datasets[0];
-  } catch (error) {
-    console.warn(`Failed to ingest consolidated server dataset ${entry.dataset_id}:`, error);
-    return null;
+  inflightIngest.set(entry.dataset_id, ingestPromise);
+  try {
+    return await ingestPromise;
+  } finally {
+    inflightIngest.delete(entry.dataset_id);
   }
 };
 
@@ -210,11 +238,17 @@ const ingestAndDispatch = async (consolidatedEntries, dispatch) => {
 
 /**
  * Reconcile IndexedDB SERVER_CONSOLIDATED entries against the live
- * manifest. Two operations:
+ * manifest. Three operations:
  *
- *   1. Sweep: any cached server-side dataset whose `original_dataset_id`
+ *   1. Dedup: when multiple cached rows share an `original_dataset_id`
+ *      (race-induced from concurrent ingest calls), keep the oldest
+ *      and delete the rest. This cleans up duplicates created before
+ *      the `inflightIngest` gate landed in `ingestConsolidatedServerDataset`,
+ *      and is cheap insurance against any future re-introduction of the
+ *      race.
+ *   2. Sweep: any cached server-side dataset whose `original_dataset_id`
  *      no longer appears in the manifest is deleted.
- *   2. Refresh: any cached server-side dataset whose manifest entry's
+ *   3. Refresh: any cached server-side dataset whose manifest entry's
  *      `name` differs from the cached `name` is deleted, so the
  *      subsequent ingest pass re-fetches it with the current metadata.
  *
@@ -235,8 +269,28 @@ const ingestAndDispatch = async (consolidatedEntries, dispatch) => {
 export const reconcileServerConsolidated = async (manifestEntries) => {
   const entryByOriginalId = new Map(manifestEntries.map((e) => [e.dataset_id, e]));
   const cached = await olmstedDB.getServerConsolidatedDatasets();
+
+  // Group by original_dataset_id and delete duplicates within each group,
+  // keeping the lexicographically-smallest storage dataset_id (which is
+  // the timestamp-prefixed value from `generateDatasetId`, so smallest =
+  // oldest). The survivors carry forward into the sweep/refresh logic.
+  const byOriginalId = new Map();
   for (const ds of cached) {
     if (!ds.original_dataset_id) continue;
+    const group = byOriginalId.get(ds.original_dataset_id) ?? [];
+    group.push(ds);
+    byOriginalId.set(ds.original_dataset_id, group);
+  }
+  const survivors = [];
+  for (const group of byOriginalId.values()) {
+    group.sort((a, b) => a.dataset_id.localeCompare(b.dataset_id));
+    survivors.push(group[0]);
+    for (const dup of group.slice(1)) {
+      await clientDataStore.removeDataset(dup.dataset_id);
+    }
+  }
+
+  for (const ds of survivors) {
     const manifestEntry = entryByOriginalId.get(ds.original_dataset_id);
     const removed = !manifestEntry;
     const renamed = manifestEntry && manifestEntry.name && manifestEntry.name !== ds.name;

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -209,6 +209,44 @@ const ingestAndDispatch = async (consolidatedEntries, dispatch) => {
 };
 
 /**
+ * Reconcile IndexedDB SERVER_CONSOLIDATED entries against the live
+ * manifest. Two operations:
+ *
+ *   1. Sweep: any cached server-side dataset whose `original_dataset_id`
+ *      no longer appears in the manifest is deleted.
+ *   2. Refresh: any cached server-side dataset whose manifest entry's
+ *      `name` differs from the cached `name` is deleted, so the
+ *      subsequent ingest pass re-fetches it with the current metadata.
+ *
+ * Cached records without `original_dataset_id` (legacy / malformed) are
+ * skipped — better to leave them than risk deleting data we can't match.
+ *
+ * UPLOAD entries are never touched: they're filtered out at the source
+ * by `getServerConsolidatedDatasets`. Callers must skip this helper
+ * entirely when the manifest fetch failed (manifest === null) so a
+ * transient network error doesn't wipe the cache.
+ *
+ * @param {Array<{dataset_id: string, name?: string}>} manifestEntries
+ *   consolidated entries from the manifest (each must have `dataset_id`;
+ *   `name` is required for the rename trigger but build-datasets-manifest
+ *   always emits it from dataset metadata)
+ * @returns {Promise<void>}
+ */
+export const reconcileServerConsolidated = async (manifestEntries) => {
+  const entryByOriginalId = new Map(manifestEntries.map((e) => [e.dataset_id, e]));
+  const cached = await olmstedDB.getServerConsolidatedDatasets();
+  for (const ds of cached) {
+    if (!ds.original_dataset_id) continue;
+    const manifestEntry = entryByOriginalId.get(ds.original_dataset_id);
+    const removed = !manifestEntry;
+    const renamed = manifestEntry && manifestEntry.name && manifestEntry.name !== ds.name;
+    if (removed || renamed) {
+      await clientDataStore.removeDataset(ds.dataset_id);
+    }
+  }
+};
+
+/**
  * Read /data/datasets.json and ingest any entries with consolidated_path.
  * Kept as an exported helper for tests; the production code path goes
  * through `getClientDatasets` instead, which is non-blocking.
@@ -232,10 +270,22 @@ export const ingestConsolidatedServerDatasets = async () => {
  */
 export const getClientDatasets = async (dispatch) => {
   try {
-    const manifest = (await fetchManifest()) || [];
-    const consolidatedEntries = manifest.filter(isConsolidatedEntry);
+    const manifest = await fetchManifest();
+    const consolidatedEntries = (manifest || []).filter(isConsolidatedEntry);
 
-    // Initial dispatch with whatever's already in IndexedDB. Don't wait
+    // Reconcile cache with the manifest *before* the initial dispatch so
+    // the splash table reflects the live state on first paint. Skipped
+    // when the manifest fetch failed (manifest === null) — a transient
+    // network error must not wipe cached server-side datasets.
+    //
+    // The `await` here is load-bearing: the subsequent ingest pass
+    // short-circuits on `findDatasetByOriginalId`, so renamed-and-deleted
+    // entries must be committed to IndexedDB before ingest runs.
+    if (manifest !== null) {
+      await reconcileServerConsolidated(consolidatedEntries);
+    }
+
+    // Initial dispatch with whatever's now in IndexedDB. Don't wait
     // on consolidated ingest.
     await dispatchClientDatasets(dispatch);
 

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -196,12 +196,23 @@ export const ingestConsolidatedServerDataset = async (entry) => {
 
       // FileProcessor sets source = UPLOAD; override to SERVER_CONSOLIDATED.
       // `temporary` is flipped to false so the Source column reads "Server".
+      // The manifest entry's `name` is authoritative — without overriding,
+      // a rename in the manifest that wasn't matched by a rebuild of the
+      // consolidated file would store the file's internal name, then
+      // reconcile's rename trigger would fire on every load (perpetual
+      // re-fetch loop).
       if (result.datasets && result.datasets[0]) {
         result.datasets[0].source = DATASET_SOURCE.SERVER_CONSOLIDATED;
         result.datasets[0].temporary = false;
+        if (entry.name) result.datasets[0].name = entry.name;
       }
 
-      await clientDataStore.storeProcessedData(result);
+      // storeProcessedData returns the actual storage dataset_id — which
+      // is the existing row's id if the storage-layer dedup short-circuited,
+      // not the throwaway from FileProcessor. Patch the returned object so
+      // callers that read `.dataset_id` see what's actually in IndexedDB.
+      const storedDatasetId = await clientDataStore.storeProcessedData(result);
+      result.datasets[0].dataset_id = storedDatasetId;
       return result.datasets[0];
     } catch (error) {
       console.warn(`Failed to ingest consolidated server dataset ${entry.dataset_id}:`, error);
@@ -300,7 +311,10 @@ export const reconcileServerConsolidated = async (manifestEntries) => {
     const manifestEntry = entryByOriginalId.get(ds.original_dataset_id);
     const removed = !manifestEntry;
     const renamed = manifestEntry && manifestEntry.name && manifestEntry.name !== ds.name;
-    const treesWiped = manifestEntry && (await olmstedDB.hasOrphanedClones(ds.dataset_id));
+    // Short-circuit: only check IndexedDB for the orphan condition when
+    // the dataset would otherwise survive (no point doing two extra
+    // queries per dataset we're about to delete anyway).
+    const treesWiped = !removed && !renamed && (await olmstedDB.hasOrphanedClones(ds.dataset_id));
     if (removed || renamed || treesWiped) {
       await clientDataStore.removeDataset(ds.dataset_id);
     }

--- a/src/actions/clientDataLoader.js
+++ b/src/actions/clientDataLoader.js
@@ -238,7 +238,7 @@ const ingestAndDispatch = async (consolidatedEntries, dispatch) => {
 
 /**
  * Reconcile IndexedDB SERVER_CONSOLIDATED entries against the live
- * manifest. Three operations:
+ * manifest. Four operations:
  *
  *   1. Dedup: when multiple cached rows share an `original_dataset_id`
  *      (race-induced from concurrent ingest calls), keep the oldest
@@ -248,9 +248,15 @@ const ingestAndDispatch = async (consolidatedEntries, dispatch) => {
  *      race.
  *   2. Sweep: any cached server-side dataset whose `original_dataset_id`
  *      no longer appears in the manifest is deleted.
- *   3. Refresh: any cached server-side dataset whose manifest entry's
- *      `name` differs from the cached `name` is deleted, so the
+ *   3. Refresh-on-rename: any cached server-side dataset whose manifest
+ *      entry's `name` differs from the cached `name` is deleted, so the
  *      subsequent ingest pass re-fetches it with the current metadata.
+ *   4. Heal-wiped-trees: any cached server-side dataset whose clones are
+ *      present but whose trees are absent is deleted. This recovers
+ *      users whose trees were collateral-damaged by the pre-fix
+ *      `removeDataset` cascade (deleted trees by clone_id rather than
+ *      namespaced ident; sibling datasets sharing clone_ids lost their
+ *      trees). The ingest pass re-fetches the file fresh.
  *
  * Cached records without `original_dataset_id` (legacy / malformed) are
  * skipped — better to leave them than risk deleting data we can't match.
@@ -294,7 +300,8 @@ export const reconcileServerConsolidated = async (manifestEntries) => {
     const manifestEntry = entryByOriginalId.get(ds.original_dataset_id);
     const removed = !manifestEntry;
     const renamed = manifestEntry && manifestEntry.name && manifestEntry.name !== ds.name;
-    if (removed || renamed) {
+    const treesWiped = manifestEntry && (await olmstedDB.hasOrphanedClones(ds.dataset_id));
+    if (removed || renamed || treesWiped) {
       await clientDataStore.removeDataset(ds.dataset_id);
     }
   }

--- a/src/utils/__tests__/olmstedDB.test.js
+++ b/src/utils/__tests__/olmstedDB.test.js
@@ -391,4 +391,59 @@ describe("storeDataset (namespacing integration)", () => {
     const renamed = datasets.find((d) => d.ident === "ds-shared-1");
     expect(renamed.original_ident).toBe("ds-shared");
   });
+
+  // Builds a processedData payload where the inner dataset carries an
+  // `original_dataset_id`. This is the field FileProcessor preserves from
+  // the source file (`fileProcessor.js:94`) and the field reconcile and
+  // dedup logic key on.
+  const buildDatasetWithOriginalId = (datasetId, originalDatasetId) => ({
+    datasetId,
+    datasets: [
+      {
+        dataset_id: datasetId,
+        original_dataset_id: originalDatasetId,
+        ident: "ds-shared",
+        name: `Dataset ${datasetId}`
+      }
+    ],
+    clones: {
+      [datasetId]: [{ clone_id: "fam-1", ident: "c1", dataset_id: datasetId, trees: [{ ident: "t1", tree_id: "t-1" }] }]
+    },
+    trees: [{ ident: "t1", tree_id: "t-1", clone_id: "fam-1", nodes: { naive: { type: "root" } } }]
+  });
+
+  it("dedups by original_dataset_id: second call returns existing id and writes nothing", async () => {
+    const firstId = await olmstedDB.storeDataset(buildDatasetWithOriginalId("upload-A", "shared-orig-id"));
+    const secondId = await olmstedDB.storeDataset(buildDatasetWithOriginalId("upload-B", "shared-orig-id"));
+
+    expect(firstId).toBe("upload-A");
+    expect(secondId).toBe("upload-A"); // existing id returned, not the new one
+    expect(await olmstedDB.datasets.count()).toBe(1);
+    expect(await olmstedDB.clones.count()).toBe(1);
+    expect(await olmstedDB.trees.count()).toBe(1);
+  });
+
+  it("concurrent storeDataset for the same source file produces exactly one row", async () => {
+    // Dexie serializes rw transactions, so the second call sees the first's
+    // commit. Without the in-transaction dedup, the rename logic treats the
+    // matching ident as a collision and stores a second row with a "-1"
+    // suffix — exactly the production bug observed at olmstedviz.org.
+    const [a, b] = await Promise.all([
+      olmstedDB.storeDataset(buildDatasetWithOriginalId("upload-A", "shared-orig-id")),
+      olmstedDB.storeDataset(buildDatasetWithOriginalId("upload-B", "shared-orig-id"))
+    ]);
+
+    expect(await olmstedDB.datasets.count()).toBe(1);
+    // Exactly one of the two returns is the "winner" id — both should equal
+    // the row that was actually stored.
+    const storedId = (await olmstedDB.datasets.toArray())[0].dataset_id;
+    expect(a).toBe(storedId);
+    expect(b).toBe(storedId);
+  });
+
+  it("does not dedup when original_dataset_id is absent (existing behavior preserved)", async () => {
+    await olmstedDB.storeDataset(buildDataset("upload-A", "shared-clone", "shared-tree"));
+    await olmstedDB.storeDataset(buildDataset("upload-B", "shared-clone", "shared-tree"));
+    expect(await olmstedDB.datasets.count()).toBe(2);
+  });
 });

--- a/src/utils/__tests__/olmstedDB.test.js
+++ b/src/utils/__tests__/olmstedDB.test.js
@@ -446,4 +446,25 @@ describe("storeDataset (namespacing integration)", () => {
     await olmstedDB.storeDataset(buildDataset("upload-B", "shared-clone", "shared-tree"));
     expect(await olmstedDB.datasets.count()).toBe(2);
   });
+
+  it("removeDataset only deletes trees from the target dataset, not siblings sharing clone_id", async () => {
+    // Regression: trees were previously deleted by `clone_id` matched
+    // against the target dataset's clones. clone_id values come from the
+    // source file (e.g. olmsted-cli), so sibling datasets that ingested
+    // the same file have identical clone_ids — the cascade wiped their
+    // trees too. The bug surfaced as "No tree nodes available" on the
+    // surviving dataset after reconcile's dedup pass removed a duplicate.
+    await olmstedDB.storeDataset(buildDataset("upload-A", "shared-clone", "shared-tree"));
+    await olmstedDB.storeDataset(buildDataset("upload-B", "shared-clone", "shared-tree"));
+    expect(await olmstedDB.trees.count()).toBe(2);
+
+    await olmstedDB.removeDataset("upload-A");
+
+    expect(await olmstedDB.datasets.count()).toBe(1);
+    expect(await olmstedDB.clones.count()).toBe(1);
+    expect(await olmstedDB.trees.count()).toBe(1);
+    // The surviving dataset's tree is intact, with its namespaced ident.
+    const tree = (await olmstedDB.trees.toArray())[0];
+    expect(tree.ident).toBe("upload-B::shared-tree");
+  });
 });

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -420,25 +420,22 @@ class OlmstedDB extends Dexie {
   }
 
   /**
-   * Remove a dataset and all associated data
+   * Remove a dataset and all associated data.
+   *
+   * Trees are deleted by namespaced ident prefix, NOT by `clone_id`.
+   * Tree `clone_id` is a source-file value (e.g. `d1_10935-igk-10935-light`)
+   * and is identical across sibling datasets that ingested the same source
+   * file — a `clone_id`-based delete would cascade and wipe trees belonging
+   * to other datasets. The `ident` field carries the `${datasetId}::`
+   * namespace prefix from `namespacedIdent` (storeDataset above), which
+   * uniquely partitions trees per dataset.
    */
   async removeDataset(datasetId) {
     try {
       await this.transaction("rw", this.datasets, this.clones, this.trees, async () => {
-        // Get all clones for this dataset
-        const clones = await this.clones.where("dataset_id").equals(datasetId).toArray();
-        const cloneIds = clones.map((c) => c.clone_id);
-
-        // Remove dataset
         await this.datasets.delete(datasetId);
-
-        // Remove clones
         await this.clones.where("dataset_id").equals(datasetId).delete();
-
-        // Remove trees for these clones using bulk operation
-        if (cloneIds.length > 0) {
-          await this.trees.where("clone_id").anyOf(cloneIds).delete();
-        }
+        await this.trees.where("ident").startsWith(`${datasetId}::`).delete();
       });
     } catch (error) {
       console.error("OlmstedDB: Failed to remove dataset:", error);

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -3,6 +3,7 @@
  */
 
 import Dexie from "dexie";
+import { DATASET_SOURCE } from "../constants/datasetSource";
 
 /**
  * Maximum suffix attempts before firstAvailable gives up. Realistic uploads
@@ -239,6 +240,31 @@ class OlmstedDB extends Dexie {
     } catch (error) {
       console.error("OlmstedDB: Failed to look up dataset by original_dataset_id:", error);
       return null;
+    }
+  }
+
+  /**
+   * Return IndexedDB datasets whose `source` is explicitly
+   * SERVER_CONSOLIDATED. Used by manifest reconciliation as the set
+   * eligible for removal/refresh.
+   *
+   * Deliberately stricter than `sourceOf()` — this checks the raw
+   * `source` field rather than falling back through legacy flags
+   * (`temporary === false` etc.). Reconciliation is destructive, so
+   * records without an explicit `source` are left alone to avoid
+   * sweeping a legacy upload whose `temporary` field happened to be
+   * absent. The cost is that pre-source-enum server entries persist
+   * forever; in practice they're rare and benign.
+   *
+   * @returns {Promise<Object[]>}
+   */
+  async getServerConsolidatedDatasets() {
+    try {
+      const all = await this.datasets.toArray();
+      return all.filter((d) => d.source === DATASET_SOURCE.SERVER_CONSOLIDATED);
+    } catch (error) {
+      console.error("OlmstedDB: Failed to enumerate server-consolidated datasets:", error);
+      return [];
     }
   }
 

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -268,8 +268,15 @@ class OlmstedDB extends Dexie {
    */
   async hasOrphanedClones(datasetId) {
     try {
-      const cloneCount = await this.clones.where("dataset_id").equals(datasetId).count();
-      if (cloneCount === 0) return false;
+      const clones = await this.clones.where("dataset_id").equals(datasetId).toArray();
+      if (clones.length === 0) return false;
+      // Some datasets legitimately have no trees (every family's tree
+      // skipped by olmsted-cli — the "0 root nodes (expected 1). Skipping
+      // this tree." warnings during processing). For those, every clone's
+      // `trees_meta` is empty, so trees were never expected; reporting
+      // them as orphaned would trigger an infinite re-fetch loop.
+      const treesExpected = clones.some((c) => c.trees_meta && c.trees_meta.length > 0);
+      if (!treesExpected) return false;
       const treeCount = await this.trees.where("ident").startsWith(`${datasetId}::`).count();
       return treeCount === 0;
     } catch (error) {

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -253,6 +253,32 @@ class OlmstedDB extends Dexie {
   }
 
   /**
+   * Detect a dataset whose clones survived but whose trees were wiped.
+   * This is the signature of users hit by the pre-fix `removeDataset`
+   * cascade (deleted trees by `clone_id` rather than namespaced ident,
+   * collateral-damaging sibling datasets that shared clone_ids). The
+   * reconcile pass uses this signal to delete the corrupted row so the
+   * subsequent ingest pass re-fetches the file fresh.
+   *
+   * Returns false for datasets with no clones (a fresh dataset that
+   * just hasn't loaded its clones yet is not corrupted).
+   *
+   * @param {string} datasetId
+   * @returns {Promise<boolean>}
+   */
+  async hasOrphanedClones(datasetId) {
+    try {
+      const cloneCount = await this.clones.where("dataset_id").equals(datasetId).count();
+      if (cloneCount === 0) return false;
+      const treeCount = await this.trees.where("ident").startsWith(`${datasetId}::`).count();
+      return treeCount === 0;
+    } catch (error) {
+      console.error("OlmstedDB: Failed to check for orphaned clones:", error);
+      return false;
+    }
+  }
+
+  /**
    * Return IndexedDB datasets whose `source` is explicitly
    * SERVER_CONSOLIDATED. Used by manifest reconciliation as the set
    * eligible for removal/refresh.

--- a/src/utils/olmstedDB.js
+++ b/src/utils/olmstedDB.js
@@ -102,7 +102,7 @@ class OlmstedDB extends Dexie {
     const { datasets, clones, trees, datasetId } = processedData;
 
     try {
-      await this.transaction("rw", this.datasets, this.clones, this.trees, async () => {
+      return await this.transaction("rw", this.datasets, this.clones, this.trees, async () => {
         // Store dataset metadata using bulk operation. Dataset records carry
         // an `ident` field from the source file (separate from `dataset_id`,
         // which is the unique storage PK). Source idents can collide across
@@ -113,13 +113,23 @@ class OlmstedDB extends Dexie {
         // `${ident}-{n}` on collision; preserve the original as
         // `original_ident`.
         //
-        // Note: this dedupe is *not* atomic across separate storeDataset
-        // calls — two parallel uploads could each see an empty `taken` set
-        // and pick the same renamed value. In practice fileUpload gates the
-        // UI behind `isProcessing`, so concurrent storeDataset is not
-        // currently reachable. Worth tightening if that ever changes.
+        // Dedup-by-`original_dataset_id`: Dexie serializes `rw` transactions
+        // on the same tables, so two concurrent calls run sequentially — but
+        // without this check the second call would see the first's row,
+        // treat the matching ident as a collision, rename to `${ident}-1`,
+        // and store a second row for the same source dataset. The
+        // application-layer `inflightIngest` gate in `clientDataLoader`
+        // already prevents this for consolidated-server ingest; the storage
+        // layer enforces it for every caller (user uploads, future writers).
+        // When a match is found we skip all writes (dataset + clones + trees)
+        // and return the existing storage id.
         if (datasets.length > 0) {
           const existing = await this.datasets.toArray();
+          const incomingOriginalId = datasets[0].original_dataset_id;
+          if (incomingOriginalId) {
+            const dup = existing.find((d) => d.original_dataset_id === incomingOriginalId);
+            if (dup) return dup.dataset_id;
+          }
           const takenIdents = new Set(existing.map((d) => d.ident).filter(Boolean));
           const datasetsToStore = datasets.map((d) => {
             if (!d.ident) return d;
@@ -201,9 +211,8 @@ class OlmstedDB extends Dexie {
         if (allTreeData.length > 0) {
           await this.trees.bulkPut(allTreeData);
         }
+        return datasetId;
       });
-
-      return datasetId;
     } catch (error) {
       console.error("OlmstedDB: Failed to store dataset:", error);
       throw error;


### PR DESCRIPTION
## Summary

What started as a single-issue fix for #301 (manifest-driven reconciliation of IndexedDB) grew during live testing into a four-layer defense-in-depth against concurrent-write and cross-dataset cascade bugs in the storage path. **All four layers were verified live on olmstedviz.org** before this description was rewritten — the user confirmed duplicates cleared and trees rendering after the final deploy.

Closes #301.

## The scope grew because each fix surfaced the next bug

| # | Bug | Surfaced as | Layer |
|---|-----|------------|-------|
| 1 | Cached `SERVER_CONSOLIDATED` rows in IndexedDB never get removed/refreshed when the manifest changes (the original issue) | Wyatt datasets persisted after deploy; "Jaffe demo dataset" name didn't update to "Jaffe demo" | Maintenance |
| 2 | `Monitor` and `App` both call `getClientDatasets` on mount; the two `ingestAndDispatch` passes race in front of `findDatasetByOriginalId` | Duplicate "Jaffe demo" and "Jaffe demo (1k)" rows on the live site, ident-renamed `…-1` | Application |
| 3 | `storeDataset` had no in-transaction dedup-by-`original_dataset_id`; an absent dedupe, not (as a misleading comment claimed) a non-atomic one — Dexie *does* serialize rw transactions on the same tables | Same as #2 from any future caller that bypasses the application gate | Storage |
| 4 | `removeDataset` deleted trees by `clone_id`, which is a source-file value (e.g. `d1_10935-igk-10935-light` from olmsted-cli) and not unique across datasets that ingested the same file. Dedup removed one duplicate and cascaded to wipe the survivor's trees too | "No tree nodes available" on the surviving dataset | Storage |

## Four-layer defense in depth

```
┌──────────────────────────────────────────────────────────────────┐
│ 1. inflightIngest Map (clientDataLoader.js)                      │
│    Concurrent ingestConsolidatedServerDataset calls for the same │
│    dataset_id share one fetch+store Promise.                     │
├──────────────────────────────────────────────────────────────────┤
│ 2. reconcileServerConsolidated (clientDataLoader.js)             │
│      a. Dedup     — group cached rows by original_dataset_id;    │
│                     keep the oldest, delete the rest.            │
│      b. Sweep     — delete rows no longer in the manifest.       │
│      c. Refresh   — drop rows whose manifest name has changed;   │
│                     ingest re-fetches with the live name.        │
│      d. Heal      — drop rows whose trees were wiped by the      │
│                     legacy removeDataset cascade. Only fires     │
│                     when trees_meta was populated (skips         │
│                     legitimately tree-free datasets).            │
├──────────────────────────────────────────────────────────────────┤
│ 3. storeDataset in-transaction dedup (olmstedDB.js)              │
│    Inside the rw transaction, if datasets[0].original_dataset_id │
│    matches an existing row, return that row's storage id and    │
│    skip all writes (dataset + clones + trees).                   │
├──────────────────────────────────────────────────────────────────┤
│ 4. removeDataset namespaced-prefix delete (olmstedDB.js)         │
│    Trees are deleted via                                         │
│      where("ident").startsWith(`${datasetId}::`)                 │
│    rather than by clone_id. Sibling datasets are isolated.       │
└──────────────────────────────────────────────────────────────────┘
```

UPLOAD entries are never touched by reconciliation. `getServerConsolidatedDatasets` filters on explicit `source === SERVER_CONSOLIDATED` — deliberately stricter than `sourceOf()`'s legacy-flag fallback, so a pre-`source`-enum upload missing `temporary: true` can't be misclassified and swept.

When the manifest fetch fails (`fetchManifest()` returns null), reconciliation is skipped entirely. Offline / 5xx / CORS must not wipe the cache or fire the heal.

The manifest's `name` is now authoritative — `ingestConsolidatedServerDataset` overrides the JSON-internal name with `entry.name` at ingest, alongside the existing `source` / `temporary` overrides. Without this, a hand-edited manifest or future olmsted-cli drift would leave manifest.name ≠ stored.name, and the rename trigger would fire on every load.

## Commits

| Commit | Purpose |
|---|---|
| `3c33c13` | Reconcile cached server datasets with live manifest on load |
| `a7f23e9` | Gate concurrent ingest + dedup in reconcile |
| `196c955` | Dedup by `original_dataset_id` inside `storeDataset` transaction |
| `5843f12` | Fix `removeDataset` cascade across sibling datasets sharing `clone_id` |
| `d39bd40` | Heal datasets whose trees were wiped by the legacy `removeDataset` cascade |
| `7f2ae63` | Address agentic code-review findings |

## Test plan

`src/actions/__tests__/clientDataLoader.test.js` and `src/utils/__tests__/olmstedDB.test.js` — **662 / 662 passing** (+18 from this PR).

Reconcile semantics:
- [x] Server entry no longer in manifest → removed from IndexedDB.
- [x] Server entry's manifest name changed → cached entry dropped (re-ingested on next pass).
- [x] Server entry's name matches → untouched, no refetch.
- [x] UPLOAD entry not in manifest → untouched.
- [x] Record missing `original_dataset_id` → skipped.
- [x] Three duplicates → collapsed to the oldest (lexicographically-smallest storage id).
- [x] Dedup + sweep in a single pass.
- [x] Healed dataset with clones-but-no-trees signature.
- [x] Negative: dataset with both clones and trees, untouched.
- [x] Negative: legitimately tree-free dataset (empty `trees_meta` on all clones) survives.

Ingest:
- [x] Concurrent `ingestConsolidatedServerDataset` calls for the same id share one fetch.
- [x] Source / temporary overrides applied on ingest.
- [x] Existing short-circuit on prior ingestion still applies.

Offline tolerance:
- [x] `fetchManifest()` returns null → reconcile skipped, cache survives.
- [x] `fetchManifest()` returns null + pseudo-orphan dataset → heal does **not** fire; defense-in-depth.

Storage:
- [x] `storeDataset` dedups by `original_dataset_id` sequentially (returns existing id, no new writes).
- [x] `storeDataset` dedups under concurrency (`Promise.all` of two stores → 1 row).
- [x] `storeDataset` preserves existing ident-rename behavior when `original_dataset_id` is absent.
- [x] `removeDataset` only deletes trees from the target dataset, even when siblings share `clone_id`.

## PRE-MERGE-CHECKLIST status

- [x] `npm run format` / `format:check` — clean
- [x] `npm run lint` — no new warnings (still 39, all pre-existing in other files)
- [x] `npm test` — **662 passing**
- [x] `npm run build` — succeeds (pre-existing `Critical dependency` warning in `server.js` is unrelated)
- [x] **Browser smoke** — verified live on olmstedviz.org. Duplicates cleared and tree+alignment view rendering correctly after the heal commit shipped.
- [x] Background `clean-code-reviewer` agent (twice — once on the original commit, once on the full diff after the cascade fixes). Findings triaged; the second pass surfaced the `hasOrphanedClones` false-positive loop and the unenforced manifest-name invariant, both fixed in `7f2ae63`.
- [x] No inline TODOs.
- [x] No function exceeds 50 lines.
- [x] Documentation sync: `ARCHITECTURE.md` gets a "Server-side dataset lifecycle" subsection.
- [x] No IndexedDB schema change (no version bump).
- [x] No new dependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
