### PR TITLE
Update master → main references after default-branch rename

### DIFF
--- a/.github/workflows/DEPLOYMENT_SETUP.md
+++ b/.github/workflows/DEPLOYMENT_SETUP.md
@@ -11,7 +11,7 @@ This workflow allows manual deployment to AWS S3 and CloudFront directly from Gi
 3. Name it: `AWS deployment`
 4. Optionally add protection rules:
    - Required reviewers
-   - Restrict to specific branches (e.g., `master` only)
+   - Restrict to specific branches (e.g., `main` only)
 
 ### 2. Configure Environment Variables
 In the "AWS deployment" environment, add these **Variables** (Settings → Environments → AWS deployment → Environment variables):

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Set git branch variable
         run: echo "BRANCH=$(git branch --show-current)" >> $GITHUB_ENV
       - name: Set image tag variable
-        run: if [ "$BRANCH" == "master" ] || [ "$BRANCH" == "" ];then echo "TAG=$(git describe --tags)" >> $GITHUB_ENV;else echo "TAG=${BRANCH//\//-}" >> $GITHUB_ENV;fi
+        run: if [ "$BRANCH" == "main" ] || [ "$BRANCH" == "" ];then echo "TAG=$(git describe --tags)" >> $GITHUB_ENV;else echo "TAG=${BRANCH//\//-}" >> $GITHUB_ENV;fi
       - name: Checkout submodules
         shell: bash
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,9 +136,9 @@ See **[PRE-MERGE-CHECKLIST.md](./PRE-MERGE-CHECKLIST.md)** for the full checklis
 
 When code is pushed to any branch, GitHub Actions:
 1. Builds Docker image using the `Dockerfile`
-2. Tags the image (master → git version tag, other branches → branch name)
+2. Tags the image (main → git version tag, other branches → branch name)
 3. Pushes to `quay.io/matsengrp/olmsted:$TAG`
-4. Updates `latest` tag when building from master
+4. Updates `latest` tag when building from main
 
 ### Website Deployment (olmstedviz.org)
 

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ Example PCP data can be found in the `olmsted-cli/example_data/` directory, demo
 
 The AIRR JSON format is described [here](https://github.com/airr-community/airr-standards/blob/master/specs/airr-schema.yaml).
 A list of tools that output this format can be found [here](https://docs.airr-community.org/en/stable/resources/rearrangement_support.html).
-For a human-readable version of the schema, see [olmstedviz.org/schema.html](http://www.olmstedviz.org/schema.html) or view [schema.html](https://github.com/matsengrp/olmsted/blob/master/schema.html) on [htmlpreview.github.io](https://htmlpreview.github.io).
+For a human-readable version of the schema, see [olmstedviz.org/schema.html](http://www.olmstedviz.org/schema.html) or view [schema.html](https://github.com/matsengrp/olmsted/blob/main/schema.html) on [htmlpreview.github.io](https://htmlpreview.github.io).
 
 ### Validation
 
@@ -339,7 +339,7 @@ For contributors and maintainers, we provide detailed documentation:
 ### Versioning
 We use git tags to tag [releases of Olmsted](https://github.com/matsengrp/olmsted/releases) using the [semver](https://semver.org/) versioning strategy.
 
-Tag messages, e.g. `Olmsted version 2.0.1 ; uses schema version 2.0.0`, contain the [version of the input data schema](https://github.com/matsengrp/olmsted/blob/master/bin/process_data.py#L18) with which a given version of Olmsted is compatible.
+Tag messages, e.g. `Olmsted version 2.0.1 ; uses schema version 2.0.0`, contain the [version of the input data schema](https://github.com/matsengrp/olmsted/blob/main/bin/process_data.py#L18) with which a given version of Olmsted is compatible.
 
 The tagged release's major version of Olmsted should always match that of its compatible schema version; should we need to make breaking changes to the schema, we will bump the major versions of both Olmsted and the input schema.
 


### PR DESCRIPTION
Follow-up to the default-branch rename (`master` → `main`). Updates the in-repo references that still said `master`.

## Changes

- **`.github/workflows/build.yml`** (functional) — the image-tag step keys off the default branch: `if [ "$BRANCH" == "master" ]` selected the `git describe --tags` version tag, else the branch name. Updated to `"main"` so default-branch builds keep getting the version tag (and the `latest` Docker tag) instead of falling through to `TAG=main`.
- **`CLAUDE.md`** — CI/CD description ("master → git version tag", "building from master").
- **`.github/workflows/DEPLOYMENT_SETUP.md`** — branch-restriction example.
- **`README.md`** — two `matsengrp/olmsted/blob/master/...` self-links → `/blob/main/...`.

## Intentionally left as `master`

External links that point at *other* projects' branches, not ours:
- `README.md` — `airr-community/airr-standards/blob/master/...`
- `src/css/bootstrapCustomized.css` — `twbs/bootstrap/blob/master/LICENSE` (vendored license header)

## Context & safety

- Rename was done GitHub-native, so open PRs were auto-retargeted, branch-protection migrated, and `master` URLs/refs redirect to `main`.
- A backup tag **`master-pre-rename-20260617`** pins the pre-rename tip (`70789f3`) as a permanent rollback anchor; the rename itself is reversible via the same API.
- Non-render, CI/docs-only change — browser smoke test not applicable. The `build.yml` edit is exercised by this PR's own CI run.
