### PR TITLE
Remove unused js-yaml direct dependency (closes #308)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## version 2.7.10 - 2026/06/22
+Removed:
+* Dropped `js-yaml` from direct `dependencies` — it was declared but never imported by any app/build JS (only Python `bin/*.py` use PyYAML, an unrelated package). It remains in the tree transitively (eslint, electron-builder use 4.2.0; babel-jest 3.14.2), so nothing changes at runtime. This also retires Dependabot #308 (which had rebased to propose a js-yaml 5.0.0 major) without pulling an unused major-version rewrite into the tree.
+
 ## version 2.7.9 - 2026/06/22
 Changed:
 * Batched dependency bumps superseding 10 Dependabot PRs (#298, #300, #303, #307, #308, #309, #310, #311, #315, #316): direct deps `js-yaml` 4.1.1→4.2.0, `@babel/core` 7.29.0→7.29.7, `multer` 2.1.1→2.2.0, `webpack-dev-server` 5.2.4→5.2.5; transitive `qs` 6.15.0→6.15.2, `express` 4.22.1→4.22.2, `tmp` 0.2.5→0.2.7, `shell-quote` 1.8.3→1.8.4, `launch-editor` 2.13.2→2.14.1, `tar` 7.5.13→7.5.16, `form-data` 4.0.5→4.0.6. All patch/minor and within existing `package.json` ranges (lockfile-only change). `npm audit` findings drop from 33 (1 critical, 4 high) to 25 (0 critical, 1 high).

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,6 @@
         "express-naked-redirect": "^0.1.3",
         "express-static-gzip": "^3.0.0",
         "fflate": "^0.8.2",
-        "js-yaml": "^4.1.1",
         "leaflet": "^1.4.0",
         "linspace": "^1.0.0",
         "lodash": "^4.18.1",
@@ -6150,6 +6149,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "dev": true,
       "license": "Python-2.0"
     },
     "node_modules/aria-query": {
@@ -13665,6 +13665,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
       "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
+      "dev": true,
       "funding": [
         {
           "type": "github",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "express-naked-redirect": "^0.1.3",
     "express-static-gzip": "^3.0.0",
     "fflate": "^0.8.2",
-    "js-yaml": "^4.1.1",
     "leaflet": "^1.4.0",
     "linspace": "^1.0.0",
     "lodash": "^4.18.1",


### PR DESCRIPTION
Removes `js-yaml` from direct `dependencies` — it was declared but **never imported by any JS** in the repo. (The `bin/*.py` `import yaml` references are Python's PyYAML, an unrelated package.)

It stays in the tree **transitively** — eslint and electron-builder use 4.2.0, babel-jest uses 3.14.2 — so nothing changes at runtime or build time. Lockfile-only beyond the one removed `package.json` line.

## Why not just merge the bump (#308)?

After the batched bumps landed, Dependabot rebased #308 to propose **js-yaml 4.2.0 → 5.0.0** — a major (TypeScript rewrite, reorganized named-export API, reduced schema set). Since we don't call js-yaml at all, bumping our direct declaration to 5.0.0 would only add an unused second copy alongside the transitive 4.2.0. Removing the phantom direct dependency is the correct fix and retires #308 (Dependabot stops proposing bumps for a dep we no longer declare).

## Verification

- No `require`/`import` of `js-yaml` anywhere in the repo (only `package.json:58`, now removed).
- `npm install` is a no-op on the lockfile; `npm ls js-yaml` still resolves it transitively for eslint / electron-builder / babel-jest.
- `npm run lint` 0 errors · `npm test` 617/617 · `npm run build` succeeds.

Closes #308.
