### PR TITLE
Tree display: leaf-label sizing (base × zoom × slider) + height cap (#325)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## version 2.7.11 - 2026/06/24
+Added:
+* Clonal-family tree: a "Label size" slider (`leaf_label_scale`, default 1) to scale leaf-label text size, alongside the other tree display controls (#325). Folded into the existing `label_size` signal as a multiplier, so the default renders identically to before; seed-label emphasis (×1.5, bold) and `show_labels` behavior are preserved. Zoom-linked scaling remains a possible follow-up (see #320).
+
 ## version 2.7.10 - 2026/06/22
 Removed:
 * Dropped `js-yaml` from direct `dependencies` — it was declared but never imported by any app/build JS (only Python `bin/*.py` use PyYAML, an unrelated package). It remains in the tree transitively (eslint, electron-builder use 4.2.0; babel-jest 3.14.2), so nothing changes at runtime. This also retires Dependabot #308 (which had rebased to propose a js-yaml 5.0.0 major) without pulling an unused major-version rewrite into the tree.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## version 2.7.11 - 2026/06/24
 Added:
-* Clonal-family tree: a "Label size" slider (`leaf_label_scale`, default 1) to scale leaf-label text size, alongside the other tree display controls (#325). Folded into the existing `label_size` signal as a multiplier, so the default renders identically to before; seed-label emphasis (×1.5, bold) and `show_labels` behavior are preserved. Zoom-linked scaling remains a possible follow-up (see #320).
+* Clonal-family tree: leaf-label font size now composes three factors (#325): a leaf-spacing-derived **base** (initial size, larger for small trees / smaller for large ones), the current **vertical zoom** level (labels grow/shrink with on-screen leaf spacing as you zoom), and a new **"Label size" slider** (`leaf_label_scale`, default 1) for explicit control. At the default full view with slider = 1 this equals the previous `clamp(leaf_size, 0, 10)`, so default rendering is unchanged; seed-label emphasis (×1.5, bold) and `show_labels` behavior are preserved.
 
 ## version 2.7.10 - 2026/06/22
 Removed:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## version 2.7.11 - 2026/06/24
 Added:
-* Clonal-family tree: leaf-label font size now composes three factors (#325): a leaf-spacing-derived **base** (initial size, larger for small trees / smaller for large ones), the current **vertical zoom** level (labels grow/shrink with on-screen leaf spacing as you zoom), and a new **"Label size" slider** (`leaf_label_scale`, default 1) for explicit control. At the default full view with slider = 1 this equals the previous `clamp(leaf_size, 0, 10)`, so default rendering is unchanged; seed-label emphasis (×1.5, bold) and `show_labels` behavior are preserved.
+* Clonal-family tree: leaf-label font size now composes three factors (#325): a spacing-derived **base** (the actual full-view px per leaf, capped at 10 — larger for small trees, smaller for large ones), the current **vertical zoom** level (labels grow with on-screen leaf spacing as you zoom), and a new **"Label size" slider** (`leaf_label_scale`, default 1, range 0.5–2). The base now uses the real leaf spacing rather than `leaf_size` (whose min-5 clamp floored the font above the true spacing on large trees and caused **label overlap**); dense trees now get sub-10 labels that fit and grow legible on zoom-in. Small trees still cap at 10 (unchanged); seed-label emphasis (×1.5, bold) and `show_labels` behavior are preserved.
 
 ## version 2.7.10 - 2026/06/22
 Removed:

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -813,6 +813,19 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
           name: "Show labels"
         })
       },
+      {
+        // User multiplier for leaf-label font size (1 = default). Folded into
+        // label_size below, so the default (1) renders identically to before.
+        name: "leaf_label_scale",
+        value: 1,
+        ...maybeAddBind({
+          input: "range",
+          min: 0.5,
+          max: 3,
+          step: 0.1,
+          name: "Label size"
+        })
+      },
       // Padding to add to the initial tree size to not clip labels
       {
         name: "leaf_label_length_limit",
@@ -823,9 +836,12 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         update: "clamp(max_leaf_size, 10, max_leaf_size)"
       },
       {
-        // Label size for tree leaves (clamped to max value of 10)
+        // Label size for tree leaves: the leaf-spacing-derived base (capped at
+        // 10) scaled by the user's leaf_label_scale slider, then clamped to a
+        // readable range. At leaf_label_scale = 1 this equals the previous
+        // clamp(leaf_size, 0, 10).
         name: "label_size",
-        update: "clamp(leaf_size, 0, 10)"
+        update: "clamp(clamp(leaf_size, 0, 10) * leaf_label_scale, 1, 40)"
       },
       {
         value: "datum",

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -1239,7 +1239,8 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
           name: "Tree height",
           input: "range",
           min: 0.2,
-          max: 0.9,
+          // Cap at 1.5 to match the scatterplot's "Plot height" control.
+          max: 1.5,
           step: 0.05
         }),
         on: [

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -837,18 +837,21 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
       },
       {
         // Leaf-label font size, composed from three factors:
-        //   1. base — leaf-spacing-derived initial size (px per leaf, capped at
-        //      10): larger for small trees, smaller for large ones.
+        //   1. base — the actual full-view vertical spacing per leaf
+        //      (span(yrange)/leaves), capped at 10. NOTE: this intentionally
+        //      does NOT use `leaf_size`, whose min-5 clamp floors the font above
+        //      the true spacing on dense trees and causes label overlap. Using
+        //      the real spacing (no floor) lets labels shrink to fit large trees.
         //   2. vertical zoom — span(yext_fencepost)/span(ydom): 1 at the default
         //      full view, >1 when zoomed in vertically (ydom narrows), so labels
-        //      grow/shrink with the on-screen leaf spacing. (ydom is top-level,
-        //      written by the tree group via push:"outer".)
+        //      grow with the on-screen leaf spacing. (ydom is top-level, written
+        //      by the tree group via push:"outer".)
         //   3. leaf_label_scale — the user's "Label size" slider.
-        // Clamped to a readable range. At full view + slider=1 this equals the
-        // previous clamp(leaf_size, 0, 10).
+        // Clamped to a readable range. Small trees still cap at 10 (unchanged);
+        // dense trees get sub-10 labels that fit and grow legible on zoom.
         name: "label_size",
         update:
-          "clamp(clamp(leaf_size, 0, 10) * (ydom && span(ydom) > 0 ? span(yext_fencepost) / span(ydom) : 1) * leaf_label_scale, 2, 60)"
+          "clamp(min(span(yrange) / leaves_count_incl_naive, 10) * (ydom && span(ydom) > 0 ? span(yext_fencepost) / span(ydom) : 1) * leaf_label_scale, 1, 60)"
       },
       {
         value: "datum",

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -821,7 +821,7 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         ...maybeAddBind({
           input: "range",
           min: 0.5,
-          max: 3,
+          max: 2,
           step: 0.1,
           name: "Label size"
         })

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -836,12 +836,19 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         update: "clamp(max_leaf_size, 10, max_leaf_size)"
       },
       {
-        // Label size for tree leaves: the leaf-spacing-derived base (capped at
-        // 10) scaled by the user's leaf_label_scale slider, then clamped to a
-        // readable range. At leaf_label_scale = 1 this equals the previous
-        // clamp(leaf_size, 0, 10).
+        // Leaf-label font size, composed from three factors:
+        //   1. base — leaf-spacing-derived initial size (px per leaf, capped at
+        //      10): larger for small trees, smaller for large ones.
+        //   2. vertical zoom — span(yext_fencepost)/span(ydom): 1 at the default
+        //      full view, >1 when zoomed in vertically (ydom narrows), so labels
+        //      grow/shrink with the on-screen leaf spacing. (ydom is top-level,
+        //      written by the tree group via push:"outer".)
+        //   3. leaf_label_scale — the user's "Label size" slider.
+        // Clamped to a readable range. At full view + slider=1 this equals the
+        // previous clamp(leaf_size, 0, 10).
         name: "label_size",
-        update: "clamp(clamp(leaf_size, 0, 10) * leaf_label_scale, 1, 40)"
+        update:
+          "clamp(clamp(leaf_size, 0, 10) * (ydom && span(ydom) > 0 ? span(yext_fencepost) / span(ydom) : 1) * leaf_label_scale, 2, 60)"
       },
       {
         value: "datum",


### PR DESCRIPTION
Closes #325.

Improves the clonal-family tree's leaf-label sizing and aligns the tree-height control with the scatterplot. Pure Vega spec change in `src/components/explorer/vega/clonalFamilyDetails.js` (used by heavy/light/single-chain trees).

## Leaf-label size

Font size now composes three factors in the `label_size` signal:

```
base     = min(span(yrange) / leaves_count_incl_naive, 10)   // true full-view px per leaf, capped at 10
vertZoom = ydom ? span(yext_fencepost) / span(ydom) : 1      // 1 at full view, >1 zoomed in vertically
size     = clamp(base * vertZoom * leaf_label_scale, 1, 60)
```

- **Base** = actual full-view leaf spacing (larger for small trees, smaller for large ones), capped at 10.
- **Vertical zoom** factor — labels grow with on-screen leaf spacing as you zoom in. `ydom`/`yext_fencepost` are top-level signals (the tree group writes `ydom` via `push:"outer"`), so this is readable where `label_size` is computed.
- **"Label size" slider** (`leaf_label_scale`, default 1, range 0.5–2) for explicit control, added alongside the other tree display controls.

### Overlap fix on large trees

The previous base used `leaf_size`, whose `clamp(height/leaves, 5, 1000)` floors at 5px — so on dense trees (real spacing < 5px) labels were sized above the spacing and **overlapped** at the initial view. Basing the font on the real spacing (no floor) makes labels fit by construction: dense trees show sub-10 labels that grow legible as you zoom in. `leaf_size` keeps its floor for leaf dot/pie sizing — only the font path changed.

Small trees are unchanged (still cap at 10 at full view, slider 1); seed-label emphasis (×1.5, bold) and `show_labels` behavior preserved.

## Tree-height control

Raised the "Tree height" slider (`viz_height_ratio`) cap from 0.9 to **1.5** to match the scatterplot's "Plot height" control. Default (0.8) and min (0.2) unchanged.

## Verification

- Vega spec parse/headless test (42) · `npm run lint` 0 errors · `npm test` 617/617 · `npm run build` · `npm run test:e2e` 2/2 · `npm run format:check` clean.
- Live checks: small tree (8 leaves, ~64px spacing) → `label_size` 10 (unchanged); 2× vertical zoom → ×2; slider ×2 → ×2; dense tree (529 leaves, ~1px spacing) → `label_size` 1 (was 5 and overlapping) and ≤ actual spacing.
