### PR TITLE
Tree: white-ring selected node + leaf-only selection band (#326)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 ## version 2.7.12 - 2026/06/24
 Changed:
-* Clonal-family tree node selection (#326): the selected node now renders as a **hollow (no-fill) black circle** — uniformly for leaf and internal nodes — and leaf node dots are always visible (they no longer collapse to a 1px point when labels are shown), so every node has a consistent marker. Selecting an **internal** node no longer draws the cross-visualization highlight band: the band spans full width on both the tree and the alignment, but the alignment has rows only for leaves, so the band was misleading for internal nodes. The band (tree + alignment) is now gated to **leaf** selections — leaf hover/selection is unchanged. Root/naive remain excluded from selection/highlight treatment.
+* Clonal-family tree node selection (#326): the selected node now renders as a **white-filled circle with a black ring** — uniformly for leaf and internal nodes — and leaf node dots are always visible (they no longer collapse to a 1px point when labels are shown), so every node has a consistent marker. Leaf labels are offset right to make room for the always-present node dot. Selecting an **internal** node no longer draws the cross-visualization highlight band: the band spans full width on both the tree and the alignment, but the alignment has rows only for leaves, so the band was misleading for internal nodes. The band (tree + alignment) is now gated to **leaf** selections — leaf hover/selection is unchanged. Root/naive remain excluded from selection/highlight treatment.
 
 ## version 2.7.11 - 2026/06/24
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## version 2.7.12 - 2026/06/24
+Changed:
+* Clonal-family tree node selection (#326): the selected node now renders as a **hollow (no-fill) black circle** — uniformly for leaf and internal nodes — and leaf node dots are always visible (they no longer collapse to a 1px point when labels are shown), so every node has a consistent marker. Selecting an **internal** node no longer draws the cross-visualization highlight band: the band spans full width on both the tree and the alignment, but the alignment has rows only for leaves, so the band was misleading for internal nodes. The band (tree + alignment) is now gated to **leaf** selections — leaf hover/selection is unchanged. Root/naive remain excluded from selection/highlight treatment.
+
 ## version 2.7.11 - 2026/06/24
 Added:
 * Clonal-family tree: leaf-label font size now composes three factors (#325): a spacing-derived **base** (the actual full-view px per leaf, capped at 10 — larger for small trees, smaller for large ones), the current **vertical zoom** level (labels grow with on-screen leaf spacing as you zoom), and a new **"Label size" slider** (`leaf_label_scale`, default 1, range 0.5–2). The base now uses the real leaf spacing rather than `leaf_size` (whose min-5 clamp floored the font above the true spacing on large trees and caused **label overlap**); dense trees now get sub-10 labels that fit and grow legible on zoom-in. Small trees still cap at 10 (unchanged); seed-label emphasis (×1.5, bold) and `show_labels` behavior are preserved.

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -175,8 +175,10 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
   const maybeAddBind = (bindConfig) => (showControls ? { bind: bindConfig } : {});
 
   // True for the currently-selected node (the clicked sequence). Used to render
-  // the selected node as a hollow (no-fill) circle across the tree node marks.
-  const selectedNodeTest = 'pts && datum.sequence_id === data("pts_store")[0].sequence_id';
+  // the selected node as a white-filled ring across the tree node marks. Guards
+  // on pts_store length inline (rather than via the `pts` signal alias) so the
+  // [0] access can never run against an empty store.
+  const selectedNodeTest = 'data("pts_store").length && datum.sequence_id === data("pts_store")[0].sequence_id';
 
   // Set of missing fields for quick lookup (e.g., "node.lbi", "clone.d_call")
   const missingSet = missingFields ? new Set(missingFields) : null;
@@ -1881,6 +1883,10 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
                 // the internal-node treatment); otherwise a solid black dot.
                 // Leaf dots stay visible even when labels are shown (no longer
                 // collapse to size 1) so every node has a consistent marker.
+                // Asymmetry vs. the `ancestor` (internal-node) mark is intentional:
+                // unselected leaf dots are 50% opacity with no stroke (pre-existing
+                // look, kept light next to labels), whereas internal nodes are
+                // opaque with a thin stroke.
                 fill: [{ test: selectedNodeTest, value: "#fff" }, { value: "#000" }],
                 fillOpacity: [{ test: selectedNodeTest, value: 1 }, { value: 0.5 }],
                 stroke: { value: "#000" },

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -1817,9 +1817,11 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
                 y: {
                   field: "y"
                 },
-                fill: { value: "#000" },
-                // Selected node = hollow circle: drop the fill and show a ring.
-                fillOpacity: [{ test: selectedNodeTest, value: 0 }, { value: 1 }],
+                // Selected node = white-filled circle with a black ring, so it
+                // stands out and occludes anything behind it; otherwise a solid
+                // black dot.
+                fill: [{ test: selectedNodeTest, value: "#fff" }, { value: "#000" }],
+                fillOpacity: { value: 1 },
                 stroke: { value: "#000" },
                 strokeWidth: [{ test: selectedNodeTest, value: 1.5 }, { value: 0.5 }],
                 size: [{ test: selectedNodeTest, value: 60 }, { value: 20 }],
@@ -1875,12 +1877,12 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
                 y: {
                   field: "y"
                 },
-                fill: { value: "#000" },
-                // Selected node = hollow circle (matches the internal-node dots);
-                // otherwise a filled dot. Leaf dots stay visible even when labels
-                // are shown (no longer collapse to size 1) so every node has a
-                // consistent marker.
-                fillOpacity: [{ test: selectedNodeTest, value: 0 }, { value: 0.5 }],
+                // Selected node = white-filled circle with a black ring (matches
+                // the internal-node treatment); otherwise a solid black dot.
+                // Leaf dots stay visible even when labels are shown (no longer
+                // collapse to size 1) so every node has a consistent marker.
+                fill: [{ test: selectedNodeTest, value: "#fff" }, { value: "#000" }],
+                fillOpacity: [{ test: selectedNodeTest, value: 1 }, { value: 0.5 }],
                 stroke: { value: "#000" },
                 strokeWidth: [{ test: selectedNodeTest, value: 1.5 }, { value: 0 }],
                 x: {
@@ -1924,7 +1926,11 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
                 y: {
                   field: "y"
                 },
-                dx: { scale: "leaf_label_offset", field: { signal: "leaf_size_by" } },
+                // Offset the label right of the leaf x. The scale term spaces
+                // labels past sized leaf pies (when "leaf size by" is active; it
+                // is undefined otherwise, hence `|| 0`); the +8 reserves room for
+                // the always-present leaf-center node dot so the label clears it.
+                dx: { signal: "(scale('leaf_label_offset', datum[leaf_size_by]) || 0) + 8" },
                 dy: { value: 3 },
                 x: {
                   field: "x"

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -174,6 +174,10 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
   // Helper to conditionally add bind property
   const maybeAddBind = (bindConfig) => (showControls ? { bind: bindConfig } : {});
 
+  // True for the currently-selected node (the clicked sequence). Used to render
+  // the selected node as a hollow (no-fill) circle across the tree node marks.
+  const selectedNodeTest = 'pts && datum.sequence_id === data("pts_store")[0].sequence_id';
+
   // Set of missing fields for quick lookup (e.g., "node.lbi", "clone.d_call")
   const missingSet = missingFields ? new Set(missingFields) : null;
 
@@ -928,7 +932,11 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         on: [
           {
             events: { signal: "pts_tuple" },
-            update: `pts_tuple && isValid(pts_tuple.y_tree) && pts_tuple.type !== '${NODE_TYPES.NAIVE}' && pts_tuple.type !== '${NODE_TYPES.ROOT}' ? pts_tuple.y_tree : null`
+            // Leaf-only: the alignment has rows for leaves, not internal nodes,
+            // so the cross-viz selection band (tree + alignment) is meaningful
+            // only for leaves. Internal nodes are signified by the hollow circle
+            // instead; naive/root stay excluded.
+            update: `pts_tuple && isValid(pts_tuple.y_tree) && pts_tuple.type === '${NODE_TYPES.LEAF}' ? pts_tuple.y_tree : null`
           }
         ]
       },
@@ -1810,16 +1818,17 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
                   field: "y"
                 },
                 fill: { value: "#000" },
+                // Selected node = hollow circle: drop the fill and show a ring.
+                fillOpacity: [{ test: selectedNodeTest, value: 0 }, { value: 1 }],
+                stroke: { value: "#000" },
+                strokeWidth: [{ test: selectedNodeTest, value: 1.5 }, { value: 0.5 }],
+                size: [{ test: selectedNodeTest, value: 60 }, { value: 20 }],
                 x: {
                   field: "x"
                 },
                 tooltip: {
                   signal: nodeTooltip
                 }
-              },
-              enter: {
-                size: { value: 20 },
-                stroke: { value: "#000" }
               }
             },
             type: "symbol",
@@ -1867,11 +1876,21 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
                   field: "y"
                 },
                 fill: { value: "#000" },
-                fillOpacity: { value: "0.5" },
+                // Selected node = hollow circle (matches the internal-node dots);
+                // otherwise a filled dot. Leaf dots stay visible even when labels
+                // are shown (no longer collapse to size 1) so every node has a
+                // consistent marker.
+                fillOpacity: [{ test: selectedNodeTest, value: 0 }, { value: 0.5 }],
+                stroke: { value: "#000" },
+                strokeWidth: [{ test: selectedNodeTest, value: 1.5 }, { value: 0 }],
                 x: {
                   field: "x"
                 },
-                size: [{ test: "show_labels", value: 1 }, { signal: "leaf_size*2" }],
+                size: [
+                  { test: selectedNodeTest, value: 60 },
+                  { test: "show_labels", value: 20 },
+                  { signal: "leaf_size*2" }
+                ],
                 cursor: { value: "pointer" },
                 tooltip: {
                   signal: nodeTooltipWithTimepoint


### PR DESCRIPTION
Closes #326.

Changes how a selected tree node is signified and fixes a misleading alignment-side highlight. Pure Vega spec change in `src/components/explorer/vega/clonalFamilyDetails.js` (heavy/light/single-chain trees).

## Problem

The selection highlight band spans full width on **both** the tree and the alignment, but the alignment only has rows for leaves — so when an **internal** node was selected, the band landed over unrelated leaf rows, implying alignment data exists for the internal node when it doesn't.

## Changes

- **Selected node = white-filled circle with a black ring**, uniformly for leaf (`leaf_center`) and internal (`ancestor`) nodes — distinct and occludes anything behind it.
- **Permanent node dots on all nodes:** leaf dots stay visible even when labels are shown (`leaf_center` no longer collapses to size 1 → size 20, matching the internal-node dots), so every node has a consistent marker.
- **Leaf labels offset** right (+8px) to clear the now-always-visible center dot. (The prior `dx` scale returned undefined when "leaf size by" is `<none>`, so labels rendered at dx 0, over the dot.)
- **Selection band gated to leaves:** `selected_leaf_y_tree` is now set only for `type === leaf`, so selecting an internal node draws **no** band on either side; leaf selection keeps the band on both tree and alignment. Hover was already leaf-only (its event sources are leaf marks), so unchanged. Naive/root stay excluded; seed emphasis preserved.

## Resulting behavior

| node type | marker | on hover | on select |
|---|---|---|---|
| leaf | black dot (always) | band on tree + alignment | white-filled ring + band on tree + alignment |
| internal | black dot | none (as today) | white-filled ring, no bands |
| root / naive | as today | excluded | excluded |

## Verification

- Vega spec parse/headless (42) · lint 0 · jest 617/617 · build · e2e 2/2 · format clean.
- Live checks: internal selection → band `null` + `ancestor` shows white fill (no band); leaf selection → band set + `leaf_center` white-filled ring; selected fill `#fff` / fillOpacity 1; leaf-label dx 8.
