### PR TITLE
CI: skip registry/Slack steps for Dependabot runs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,12 +61,17 @@ jobs:
           exit 1
       - name: Run example in the Docker image
         run: docker run --rm -p 8080:3999 quay.io/matsengrp/olmsted:$TAG & sleep 20 && curl -I localhost:8080
+      # Registry and Slack steps need repository secrets, which GitHub withholds
+      # from Dependabot-triggered runs. Skip them for dependabot so its PRs go
+      # green on build+test+e2e instead of failing on inaccessible secrets.
       - name: Login to Registry
+        if: github.actor != 'dependabot[bot]'
         run: docker login quay.io -u ${{ secrets.QUAY_USERNAME }} --password ${{ secrets.QUAY_PASSWORD }}
       - name: publish to Registry
+        if: github.actor != 'dependabot[bot]'
         run: docker push quay.io/matsengrp/olmsted:$TAG && docker tag quay.io/matsengrp/olmsted:$TAG quay.io/matsengrp/olmsted:latest && docker push quay.io/matsengrp/olmsted:latest
       - name: Slack Notification
-        if: failure()
+        if: failure() && github.actor != 'dependabot[bot]'
         uses: slackapi/slack-github-action@v3
         with:
           webhook: ${{ secrets.SLACK_NOTIFICATION_WEBHOOK }}


### PR DESCRIPTION
## Summary

Dependabot-triggered workflow runs execute **without access to repository secrets**, so the secret-dependent steps in `build.yml` fail on every Dependabot PR — even when build, tests, and Playwright e2e all pass. This showed up on the `websocket-driver` bump (PR #338): the only red checks were `Login to Registry` and `Slack Notification`, with the annotation *"Missing input! Either a method or webhook is required"* (the Slack action got an empty webhook secret).

This gates the three secret-dependent steps on `github.actor != 'dependabot[bot]'`:

- **Login to Registry** — needs `QUAY_USERNAME` / `QUAY_PASSWORD`
- **publish to Registry** — pushes the image (only meaningful after login)
- **Slack Notification** — needs `SLACK_NOTIFICATION_WEBHOOK`

Result: Dependabot PRs report green on the checks they can actually run (install → test → e2e → Docker build → run example), instead of a misleading ❌ that hits every one of them identically.

## Scope / non-goals

- No change to behavior on normal (non-Dependabot) pushes — those steps still run exactly as before, on all branches.
- Registry publish already runs on every branch today; this PR does not alter that, only the Dependabot carve-out.

## Testing

- YAML validated (`yaml.safe_load`).
- Docs/CI-only change — no application source touched, so the browser/Vega smoke steps of PRE-MERGE-CHECKLIST are N/A. The build/test/e2e steps run in CI on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)