### PR TITLE
Dedupe tooltip labels so colliding fields can't break Vega parsing

### DIFF
--- a/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
+++ b/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
@@ -225,6 +225,21 @@ describe("concatTreeWithAlignmentSpec", () => {
       const noControls = concatTreeWithAlignmentSpec({ showControls: false });
       expect(() => vega.parse(noControls)).not.toThrow();
     });
+
+    it("parses when node metadata reuses a built-in tooltip label", () => {
+      // Regression: a CLI-supplied node field (e.g. AIRR-C v2 `node_type`)
+      // whose label collides with the built-in topological `type` field
+      // ("Node Type") used to emit a duplicate object key in the tooltip
+      // signal — an invalid Vega expression that failed to parse and broke
+      // tree/alignment rendering entirely.
+      const resolved = resolveFieldMetadata({
+        node: {
+          node_type: { type: "categorical", display: "tooltip", label: "Node Type" },
+        },
+      });
+      const collidingSpec = concatTreeWithAlignmentSpec({ fieldMetadata: resolved });
+      expect(() => vega.parse(collidingSpec)).not.toThrow();
+    });
   });
 });
 

--- a/src/utils/__tests__/fieldMetadata.test.js
+++ b/src/utils/__tests__/fieldMetadata.test.js
@@ -1,0 +1,59 @@
+import { buildVegaTooltipExpr } from "../fieldMetadata";
+
+describe("buildVegaTooltipExpr", () => {
+  it("builds a Vega object literal keyed by label", () => {
+    const expr = buildVegaTooltipExpr([
+      { field: "sequence_id", label: "Sequence ID" },
+      { field: "distance", label: "Distance", format: ".3f" },
+    ]);
+    expect(expr).toBe(
+      '{"Sequence ID": datum["sequence_id"], "Distance": format(datum["distance"], ".3f")}'
+    );
+  });
+
+  it("supports dot-notation nested accessors", () => {
+    const expr = buildVegaTooltipExpr([{ field: "sample.locus", label: "Locus" }]);
+    expect(expr).toBe('{"Locus": datum["sample"] ? datum["sample"]["locus"] : ""}');
+  });
+
+  it("applies a null fallback when requested", () => {
+    const expr = buildVegaTooltipExpr([{ field: "parent", label: "Parent ID" }], {
+      nullFallback: "N/A",
+    });
+    expect(expr).toBe('{"Parent ID": datum["parent"] != null ? datum["parent"] : "N/A"}');
+  });
+
+  describe("label de-duplication", () => {
+    it("drops a later field whose label duplicates an earlier one", () => {
+      // The tooltip is a Vega object literal; a repeated key is invalid and
+      // fails to parse. First occurrence wins (builtins are ordered first).
+      const expr = buildVegaTooltipExpr([
+        { field: "type", label: "Node Type" },
+        { field: "node_type", label: "Node Type" },
+      ]);
+      // Only one "Node Type" key, backed by the first (topological) field.
+      expect(expr).toBe('{"Node Type": datum["type"]}');
+      expect(expr).not.toContain("node_type");
+    });
+
+    it("never emits a duplicate object key", () => {
+      const expr = buildVegaTooltipExpr([
+        { field: "a", label: "Dup" },
+        { field: "b", label: "Dup" },
+        { field: "c", label: "Unique" },
+      ]);
+      const keys = [...expr.matchAll(/"([^"]+)":/g)].map((m) => m[1]);
+      expect(keys).toEqual([...new Set(keys)]);
+      expect(keys).toEqual(["Dup", "Unique"]);
+    });
+
+    it("keeps distinct labels untouched", () => {
+      const expr = buildVegaTooltipExpr([
+        { field: "type", label: "Node Type" },
+        { field: "node_type", label: "Observed/Inferred" },
+      ]);
+      expect(expr).toContain('"Node Type": datum["type"]');
+      expect(expr).toContain('"Observed/Inferred": datum["node_type"]');
+    });
+  });
+});

--- a/src/utils/fieldMetadata.js
+++ b/src/utils/fieldMetadata.js
@@ -54,7 +54,27 @@ export function buildVegaTooltipExpr(fields, options = {}) {
   const { nullFallback = null, quoteStyle = "double" } = options;
   const q = quoteStyle === "single" ? "'" : '"';
 
-  const parts = fields.map((f) => {
+  // De-duplicate by label. The tooltip is a Vega object literal, and two
+  // fields sharing a label would emit the same key twice — an invalid
+  // expression that fails to parse and breaks rendering entirely (e.g. the
+  // built-in topological `type` field and a CLI-supplied `node_type` field
+  // both labeled "Node Type"). First occurrence wins, since builtins are
+  // ordered first and are the more canonical owner of a label.
+  const seenLabels = new Set();
+  const uniqueFields = fields.filter((f) => {
+    if (seenLabels.has(f.label)) {
+      // eslint-disable-next-line no-console
+      console.warn(
+        `buildVegaTooltipExpr: dropping field "${f.field}" — its label ` +
+          `"${f.label}" is already used by an earlier field in this tooltip.`
+      );
+      return false;
+    }
+    seenLabels.add(f.label);
+    return true;
+  });
+
+  const parts = uniqueFields.map((f) => {
     const label = quoteStyle === "single" ? f.label.replace(/'/g, "\\'") : f.label.replace(/"/g, '\\"');
 
     // Custom expression takes precedence


### PR DESCRIPTION
## Problem

The node/tree tooltip is a Vega **object literal keyed by field label**. `buildNodeTooltipSignal` (and the scatterplot builder) de-duplicate fields by **name**, but not by **label** — so two different fields that resolve to the same label emit the same object key twice. Vega can't parse an object literal with a duplicate key, so the tree + alignment view fails to render with:

```
Tree visualization error: Expression parse error: ({"Node Type": ... , "Node Type": ... })
```

This surfaced with the new **olmsted-cli AIRR-C v2 (`airr2`) input format** (matsengrp/olmsted-cli#37), which adds a node field `node_type` (observed vs inferred ancestor). Its humanized label "Node Type" collided with the built-in **topological** `type` field (also "Node Type" in `fieldDefaults.js`), producing the duplicate key.

It's a general latent bug: *any* dataset with a field whose label matches another field's (including a built-in) would hit the same invalid-Vega error.

## Fix

Harden the shared `buildVegaTooltipExpr` (`src/utils/fieldMetadata.js`) to drop any later field whose label duplicates an earlier one — **first-wins**, since built-ins are ordered first and are the canonical owner of a label — with a `console.warn` on drop. This guarantees the tooltip object literal never has a duplicate key, protecting **every** caller (tree, scatterplot, clonal-family details), not just this one field.

## Tests

- `src/utils/__tests__/fieldMetadata.test.js` — unit tests for `buildVegaTooltipExpr`: object-literal shape, dot-notation accessors, null fallback, and the new label de-dup (first-wins, never emits a duplicate key, distinct labels untouched).
- `clonalFamilyDetails.test.js` — a regression test that a tree spec built with a colliding node label (`node_type` → "Node Type") still `vega.parse()`s without throwing.

Verified the new tests **fail without the fix** (3 failures) and pass with it. Full tooltip-adjacent suites: **357 passing**.

## Companion CLI change

matsengrp/olmsted-cli#37 also relabels `node_type` → **"Observed/Inferred"** so both fields show up **distinctly** in the tooltip. This webapp change is the defensive backstop so the whole class of duplicate-label collisions can never break rendering again (and older/other CLI outputs are covered too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
