### PR TITLE
Add regression test for cross-dataset tree content isolation

### DIFF
--- a/src/utils/__tests__/olmstedDB.test.js
+++ b/src/utils/__tests__/olmstedDB.test.js
@@ -447,6 +447,46 @@ describe("storeDataset (namespacing integration)", () => {
     expect(await olmstedDB.datasets.count()).toBe(2);
   });
 
+  it("resolves distinct, correct tree content per dataset when tree idents collide (issue #304)", async () => {
+    // Reproduces the reported symptom directly: two datasets derived from
+    // the same source (e.g. before/after an olmsted-cli fix) share tree
+    // idents, but carry different node data (distance/length here). Storing
+    // both and reading each back by its own namespaced ident must not
+    // cross-talk — last-write-wins on the shared raw ident would silently
+    // serve dataset B's nodes when viewing dataset A.
+    const buildWithNodeData = (datasetId, nodeDistance) => ({
+      datasetId,
+      datasets: [{ dataset_id: datasetId, ident: "ds-shared", name: `Dataset ${datasetId}` }],
+      clones: {
+        [datasetId]: [
+          {
+            clone_id: "fam-1",
+            ident: "shared-clone",
+            dataset_id: datasetId,
+            trees: [{ ident: "shared-tree", tree_id: "t-1" }]
+          }
+        ]
+      },
+      trees: [
+        {
+          ident: "shared-tree",
+          tree_id: "t-1",
+          clone_id: "fam-1",
+          nodes: { naive: { type: "root", distance: nodeDistance } }
+        }
+      ]
+    });
+
+    await olmstedDB.storeDataset(buildWithNodeData("upload-A", 0));
+    await olmstedDB.storeDataset(buildWithNodeData("upload-B", 0.5));
+
+    const treeA = await olmstedDB.getTreeByIdent(namespacedIdent("upload-A", "shared-tree"));
+    const treeB = await olmstedDB.getTreeByIdent(namespacedIdent("upload-B", "shared-tree"));
+
+    expect(treeA.nodes.find((n) => n.sequence_id === "naive").distance).toBe(0);
+    expect(treeB.nodes.find((n) => n.sequence_id === "naive").distance).toBe(0.5);
+  });
+
   it("removeDataset only deletes trees from the target dataset, not siblings sharing clone_id", async () => {
     // Regression: trees were previously deleted by `clone_id` matched
     // against the target dataset's clones. clone_id values come from the


### PR DESCRIPTION
## Summary

Closes #304 (already fixed — see below; this PR adds the missing coverage).

Issue 304 reported that two datasets sharing clone/tree idents would cross-talk on IndexedDB: viewing dataset A's tree would silently show dataset B's node data (`distance`/`length`), last-write-wins, with a proposed fix of migrating the `trees` Dexie table to a compound `[dataset_id+ident]` primary key.

That bug is already fixed, and has been since before the issue was filed:

- PR #283 (`262b985`, 2026-05-08) introduced `namespacedIdent(datasetId, ident)`, which prefixes clone and tree idents with their storage `dataset_id` at the point they're written (`"upload-A::shared-tree"`). Since the primary key *value* is already dataset-unique, the existing single-field `trees: "ident, ..."` schema never collides — no compound-key migration needed.
- `5843f12` / `d39bd40` (2026-06-01) separately fixed `removeDataset`'s delete cascade, which the issue also flagged as deleting trees by unnamespaced `clone_id` (collateral-damaging sibling datasets). It's already scoped by ident-prefix.
- Issue 304 was filed 2026-06-10 — after both fixes had landed.

Traced the full call chain the issue worried about re: "secondary caches" (Redux `trees.cache`, the `recentTrees` in-memory Map): the namespaced ident value flows through `clone.trees_meta[].ident` → `clone.trees` (`clientDataStore.js:134`) → `selectFamily` → `getClientTree` → `clientDataStore.getTree` → `olmstedDB.getTreeByIdent`, all the way down. Those caches are keyed by this same namespaced value end-to-end — despite being confusingly named `tree_id` throughout that path, they're already dataset-scoped. No additional threading needed.

## What was missing

The existing "namespacing integration" test suite covered *row counts* after a collision (`trees.count()` stays 2, not 1) but nothing checked that the retrieved tree **content** was actually correct per dataset — the literal symptom the issue reported. Added that: two datasets with fully colliding clone/tree idents but different node data (`distance: 0` vs `distance: 0.5`), read back independently via `getTreeByIdent`, asserting each dataset's own value comes back untouched.

## Known, narrower residual gap (not fixed here, not the reported bug)

`clientDataStore.getTree`'s fallback path (`getTreeForClone`, only reached when a direct ident lookup fails — legacy "surprise-format" files that predate `trees_meta`) still looks up by raw, unnamespaced `clone_id`. Low-probability and legacy-only; not what issue 304's repro (via `olmsted merge`, which produces proper idents) would hit. Flagging for visibility, not fixing in this PR.

## Test plan

- [x] New test: `"resolves distinct, correct tree content per dataset when tree idents collide (issue #304)"` — passes
- [x] Full existing `olmstedDB.test.js` suite (32 tests) still passes
- [x] Full suite: 627/627 passing
- [x] `npm run build` — clean
- [x] Format/lint: no new issues (2 pre-existing unrelated warnings in other files, confirmed present on `main` before this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)