### PR TITLE
Fix trailing-comma lint errors in two test files

### DIFF
--- a/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
+++ b/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
@@ -234,8 +234,8 @@ describe("concatTreeWithAlignmentSpec", () => {
       // tree/alignment rendering entirely.
       const resolved = resolveFieldMetadata({
         node: {
-          node_type: { type: "categorical", display: "tooltip", label: "Node Type" },
-        },
+          node_type: { type: "categorical", display: "tooltip", label: "Node Type" }
+        }
       });
       const collidingSpec = concatTreeWithAlignmentSpec({ fieldMetadata: resolved });
       expect(() => vega.parse(collidingSpec)).not.toThrow();

--- a/src/utils/__tests__/fieldMetadata.test.js
+++ b/src/utils/__tests__/fieldMetadata.test.js
@@ -4,11 +4,9 @@ describe("buildVegaTooltipExpr", () => {
   it("builds a Vega object literal keyed by label", () => {
     const expr = buildVegaTooltipExpr([
       { field: "sequence_id", label: "Sequence ID" },
-      { field: "distance", label: "Distance", format: ".3f" },
+      { field: "distance", label: "Distance", format: ".3f" }
     ]);
-    expect(expr).toBe(
-      '{"Sequence ID": datum["sequence_id"], "Distance": format(datum["distance"], ".3f")}'
-    );
+    expect(expr).toBe('{"Sequence ID": datum["sequence_id"], "Distance": format(datum["distance"], ".3f")}');
   });
 
   it("supports dot-notation nested accessors", () => {
@@ -18,7 +16,7 @@ describe("buildVegaTooltipExpr", () => {
 
   it("applies a null fallback when requested", () => {
     const expr = buildVegaTooltipExpr([{ field: "parent", label: "Parent ID" }], {
-      nullFallback: "N/A",
+      nullFallback: "N/A"
     });
     expect(expr).toBe('{"Parent ID": datum["parent"] != null ? datum["parent"] : "N/A"}');
   });
@@ -29,7 +27,7 @@ describe("buildVegaTooltipExpr", () => {
       // fails to parse. First occurrence wins (builtins are ordered first).
       const expr = buildVegaTooltipExpr([
         { field: "type", label: "Node Type" },
-        { field: "node_type", label: "Node Type" },
+        { field: "node_type", label: "Node Type" }
       ]);
       // Only one "Node Type" key, backed by the first (topological) field.
       expect(expr).toBe('{"Node Type": datum["type"]}');
@@ -40,7 +38,7 @@ describe("buildVegaTooltipExpr", () => {
       const expr = buildVegaTooltipExpr([
         { field: "a", label: "Dup" },
         { field: "b", label: "Dup" },
-        { field: "c", label: "Unique" },
+        { field: "c", label: "Unique" }
       ]);
       const keys = [...expr.matchAll(/"([^"]+)":/g)].map((m) => m[1]);
       expect(keys).toEqual([...new Set(keys)]);
@@ -50,7 +48,7 @@ describe("buildVegaTooltipExpr", () => {
     it("keeps distinct labels untouched", () => {
       const expr = buildVegaTooltipExpr([
         { field: "type", label: "Node Type" },
-        { field: "node_type", label: "Observed/Inferred" },
+        { field: "node_type", label: "Observed/Inferred" }
       ]);
       expect(expr).toContain('"Node Type": datum["type"]');
       expect(expr).toContain('"Observed/Inferred": datum["node_type"]');


### PR DESCRIPTION
## Summary
- `src/utils/__tests__/fieldMetadata.test.js` and `src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js` had trailing commas that violate this repo's `comma-dangle` ESLint rule, making `npm run lint` fail with 7 errors on `main`.
- Reformatted both with `npx prettier --write` (the repo's configured style has no trailing commas); no logic changes.

## Test plan
- [x] `npm run lint` — 0 errors (was 7)
- [x] `npm run format:check` — clean
- [x] `npm test` — 627 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)