### PR TITLE
Tree view: order children by leaf count / max leaf depth / multiplicity (#331)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,8 @@ See the 2.x entries below for the detailed per-change history.
 
 ## version 3.0.1 - 2026/08/05
 Added:
-* The tree (Phylogeny) view has an **"Order children by" control** (#331) for ladderizing sibling clades: input order (default, today's behavior), number of leaves, max leaf depth, or total leaf multiplicity, plus an "Order children descending" toggle. The per-node subtree aggregates backing this are computed once in `computeTreeData` (`src/selectors/trees.js`), memoized on the tree itself — switching the ordering control re-lays-out the tree but never re-triggers that computation. Implemented as Vega-bound signals (`child_order_by`, `child_order_desc`), matching every other tree control, so the choice is captured by the named-config system like `branch_color_by`/`show_labels`/etc.
+* The tree (Phylogeny) view has an **"Order children by" control** (#331) for ladderizing sibling clades: input order (default, today's behavior), number of leaves, max leaf depth (topological), max leaf distance from root (branch length — only offered when the tree has distance data, matching the "Branch length" control), or total leaf multiplicity, plus an "Order children descending" toggle. The per-node subtree aggregates backing this are computed once in `computeTreeData` (`src/selectors/trees.js`), memoized on the tree itself — switching the ordering control re-lays-out the tree but never re-triggers that computation. Implemented as Vega-bound signals (`child_order_by`, `child_order_desc`), matching every other tree control, so the choice is captured by the named-config system like `branch_color_by`/`show_labels`/etc.
+* The tree's **node tooltip now shows the subtree ordering aggregates** (leaves in subtree, max leaf depth, max leaf distance, total multiplicity) driving the new "Order children by" control, so the values are visible without devtools.
 
 ## version 2.7.16 - 2026/06/26
 Added:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,10 @@ dependencies and frameworks. Headline changes since the 2.x line:
 
 See the 2.x entries below for the detailed per-change history.
 
+## version 3.0.1 - 2026/08/05
+Added:
+* The tree (Phylogeny) view has an **"Order children by" control** (#331) for ladderizing sibling clades: input order (default, today's behavior), number of leaves, max leaf depth, or total leaf multiplicity, plus an "Order children descending" toggle. The per-node subtree aggregates backing this are computed once in `computeTreeData` (`src/selectors/trees.js`), memoized on the tree itself — switching the ordering control re-lays-out the tree but never re-triggers that computation. Implemented as Vega-bound signals (`child_order_by`, `child_order_desc`), matching every other tree control, so the choice is captured by the named-config system like `branch_color_by`/`show_labels`/etc.
+
 ## version 2.7.16 - 2026/06/26
 Added:
 * The clonal-families table has a **"Columns" picker** to show/hide columns (#323). Action/identity columns (Star, Select, Info, Naive sequence, Family ID) are locked visible; all other columns are toggleable. The picker lists **every clone variable in `field_metadata`** — both `dropdown` and `tooltip` display fields — so any data field can be added as a column; field-metadata-derived extras default to hidden (opt-in), while the standard columns default to visible. Per-column visibility lives in Redux and persists per browser via `sessionStorage`. (CSV export still includes the full standard column set.)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ See the 2.x entries below for the detailed per-change history.
 ## version 3.0.1 - 2026/08/05
 Added:
 * The tree (Phylogeny) view has an **"Order children by" control** (#331) for ladderizing sibling clades: input order (default, today's behavior), number of leaves, max leaf depth (topological), max leaf distance from root (branch length — only offered when the tree has distance data, matching the "Branch length" control), or total leaf multiplicity, plus an "Order children descending" toggle. The per-node subtree aggregates backing this are computed once in `computeTreeData` (`src/selectors/trees.js`), memoized on the tree itself — switching the ordering control re-lays-out the tree but never re-triggers that computation. Implemented as Vega-bound signals (`child_order_by`, `child_order_desc`), matching every other tree control, so the choice is captured by the named-config system like `branch_color_by`/`show_labels`/etc.
-* The tree's **node tooltip now shows the subtree ordering aggregates** (leaves in subtree, max leaf depth, max leaf distance, total multiplicity) driving the new "Order children by" control, so the values are visible without devtools.
+* The tree's **node tooltip now shows the subtree ordering aggregates** (leaves in subtree, max leaf depth, max leaf distance, total multiplicity) driving the new "Order children by" control, so the values are visible without devtools. Gated behind a **"Show ordering info in tooltip" checkbox** (default off), implemented as a runtime toggle on the tooltip's Vega expression rather than a spec rebuild.
 
 ## version 2.7.16 - 2026/06/26
 Added:

--- a/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
+++ b/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
@@ -241,6 +241,43 @@ describe("concatTreeWithAlignmentSpec", () => {
       expect(() => vega.parse(collidingSpec)).not.toThrow();
     });
   });
+
+  describe("sibling ordering (#331)", () => {
+    // leaf-1 (multiplicity 3) and leaf-2 (multiplicity 1) are both direct
+    // children of "root" in treeNodesData; sorting by total multiplicity
+    // should swap their relative y_tree order depending on direction.
+    const runWithOrdering = async (childOrderBy, childOrderDesc) => {
+      const runtime = vega.parse(spec);
+      const view = new vega.View(runtime, { renderer: "none" });
+      view.data("source_0", treeNodesData);
+      view.data("source_1", treeAlignmentData);
+      view.data("naive_data", naiveGeneRegionData);
+      view.data("cdr_bounds", cdrBoundsData);
+      view.data("leaves_count_incl_naive", leavesCountData);
+      view.data("seed", seedData);
+      if (childOrderBy !== undefined) view.signal("child_order_by", childOrderBy);
+      if (childOrderDesc !== undefined) view.signal("child_order_desc", childOrderDesc);
+      await view.runAsync();
+      const byId = Object.fromEntries(view.data("tree").map((d) => [d.sequence_id, d]));
+      view.finalize();
+      return byId;
+    };
+
+    it("defaults to input order (leaf-1 before leaf-2, as in treeNodesData)", async () => {
+      const byId = await runWithOrdering();
+      expect(byId["leaf-1"].y_tree).toBeLessThan(byId["leaf-2"].y_tree);
+    });
+
+    it("orders ascending by total multiplicity (leaf-2, mult 1, before leaf-1, mult 3)", async () => {
+      const byId = await runWithOrdering("total_multiplicity", false);
+      expect(byId["leaf-2"].y_tree).toBeLessThan(byId["leaf-1"].y_tree);
+    });
+
+    it("descending reverses the order (leaf-1 before leaf-2)", async () => {
+      const byId = await runWithOrdering("total_multiplicity", true);
+      expect(byId["leaf-1"].y_tree).toBeLessThan(byId["leaf-2"].y_tree);
+    });
+  });
 });
 
 describe("seqAlignSpec", () => {

--- a/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
+++ b/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
@@ -283,6 +283,22 @@ describe("concatTreeWithAlignmentSpec", () => {
       expect(byId["leaf-1"].y_tree).toBeLessThan(byId["leaf-2"].y_tree);
     });
   });
+
+  describe("ordering tooltip toggle (#331)", () => {
+    it("has a 'Show ordering info in tooltip' checkbox signal, defaulting to off", () => {
+      const signal = spec.signals.find((s) => s.name === "show_ordering_tooltip_fields");
+      expect(signal).toBeDefined();
+      expect(signal.value).toBe(false);
+    });
+
+    it("wraps the node tooltip content in a show_ordering_tooltip_fields conditional", () => {
+      const specString = JSON.stringify(spec);
+      // The conditional itself, and the ordering fields it gates, must both
+      // be present in the built tooltip expression.
+      expect(specString).toContain("show_ordering_tooltip_fields");
+      expect(specString).toContain("Leaves in subtree");
+    });
+  });
 });
 
 describe("seqAlignSpec", () => {

--- a/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
+++ b/src/components/explorer/vega/__tests__/clonalFamilyDetails.test.js
@@ -277,6 +277,11 @@ describe("concatTreeWithAlignmentSpec", () => {
       const byId = await runWithOrdering("total_multiplicity", true);
       expect(byId["leaf-1"].y_tree).toBeLessThan(byId["leaf-2"].y_tree);
     });
+
+    it("orders ascending by max leaf distance (leaf-1, dist 0.05, before leaf-2, dist 0.08) — the opposite of multiplicity order", async () => {
+      const byId = await runWithOrdering("max_leaf_distance", false);
+      expect(byId["leaf-1"].y_tree).toBeLessThan(byId["leaf-2"].y_tree);
+    });
   });
 });
 

--- a/src/components/explorer/vega/__tests__/vegaMockData.js
+++ b/src/components/explorer/vega/__tests__/vegaMockData.js
@@ -52,9 +52,12 @@ export const scatterplotDatasetsData = [{ dataset_id: "dataset-1", name: "Test D
 
 // Minimal tree: naive → root → leaf1, leaf2
 // Ordering aggregates (subtree_leaf_count / subtree_max_leaf_depth /
-// subtree_total_multiplicity / input_order_index) mirror what
-// computeTreeData (src/selectors/trees.js) would compute for this shape, so
-// the "sibling ordering (#331)" runtime tests exercise real field values.
+// subtree_max_leaf_distance / subtree_total_multiplicity / input_order_index)
+// mirror what computeTreeData (src/selectors/trees.js) would compute for this
+// shape, so the "sibling ordering (#331)" runtime tests exercise real field
+// values. Note leaf-1 (distance 0.05, multiplicity 3) and leaf-2 (distance
+// 0.08, multiplicity 1) disagree between distance and multiplicity ordering —
+// deliberately, so tests can tell the two fields apart.
 export const treeNodesData = [
   {
     sequence_id: "naive",
@@ -65,6 +68,7 @@ export const treeNodesData = [
     lbr: 0,
     subtree_leaf_count: 2,
     subtree_max_leaf_depth: 2,
+    subtree_max_leaf_distance: 0.08,
     subtree_total_multiplicity: 4,
     input_order_index: 0
   },
@@ -77,6 +81,7 @@ export const treeNodesData = [
     lbr: 1.0,
     subtree_leaf_count: 2,
     subtree_max_leaf_depth: 2,
+    subtree_max_leaf_distance: 0.08,
     subtree_total_multiplicity: 4,
     input_order_index: 1
   },
@@ -94,6 +99,7 @@ export const treeNodesData = [
     ],
     subtree_leaf_count: 1,
     subtree_max_leaf_depth: 2,
+    subtree_max_leaf_distance: 0.05,
     subtree_total_multiplicity: 3,
     input_order_index: 2
   },
@@ -108,6 +114,7 @@ export const treeNodesData = [
     timepoint_multiplicities: [{ timepoint_id: "day-0", multiplicity: 1 }],
     subtree_leaf_count: 1,
     subtree_max_leaf_depth: 2,
+    subtree_max_leaf_distance: 0.08,
     subtree_total_multiplicity: 1,
     input_order_index: 3
   }

--- a/src/components/explorer/vega/__tests__/vegaMockData.js
+++ b/src/components/explorer/vega/__tests__/vegaMockData.js
@@ -51,6 +51,10 @@ export const scatterplotDatasetsData = [{ dataset_id: "dataset-1", name: "Test D
 // --- clonalFamilyDetails.js: tree + alignment ---
 
 // Minimal tree: naive → root → leaf1, leaf2
+// Ordering aggregates (subtree_leaf_count / subtree_max_leaf_depth /
+// subtree_total_multiplicity / input_order_index) mirror what
+// computeTreeData (src/selectors/trees.js) would compute for this shape, so
+// the "sibling ordering (#331)" runtime tests exercise real field values.
 export const treeNodesData = [
   {
     sequence_id: "naive",
@@ -58,7 +62,11 @@ export const treeNodesData = [
     type: "naive",
     distance: 0,
     lbi: 0,
-    lbr: 0
+    lbr: 0,
+    subtree_leaf_count: 2,
+    subtree_max_leaf_depth: 2,
+    subtree_total_multiplicity: 4,
+    input_order_index: 0
   },
   {
     sequence_id: "root",
@@ -66,7 +74,11 @@ export const treeNodesData = [
     type: "root",
     distance: 0.01,
     lbi: 0.5,
-    lbr: 1.0
+    lbr: 1.0,
+    subtree_leaf_count: 2,
+    subtree_max_leaf_depth: 2,
+    subtree_total_multiplicity: 4,
+    input_order_index: 1
   },
   {
     sequence_id: "leaf-1",
@@ -79,7 +91,11 @@ export const treeNodesData = [
     timepoint_multiplicities: [
       { timepoint_id: "day-0", multiplicity: 2 },
       { timepoint_id: "day-7", multiplicity: 1 }
-    ]
+    ],
+    subtree_leaf_count: 1,
+    subtree_max_leaf_depth: 2,
+    subtree_total_multiplicity: 3,
+    input_order_index: 2
   },
   {
     sequence_id: "leaf-2",
@@ -89,7 +105,11 @@ export const treeNodesData = [
     multiplicity: 1,
     cluster_multiplicity: 1,
     affinity: 0.6,
-    timepoint_multiplicities: [{ timepoint_id: "day-0", multiplicity: 1 }]
+    timepoint_multiplicities: [{ timepoint_id: "day-0", multiplicity: 1 }],
+    subtree_leaf_count: 1,
+    subtree_max_leaf_depth: 2,
+    subtree_total_multiplicity: 1,
+    input_order_index: 3
   }
 ];
 

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -65,7 +65,21 @@ const treeSelectLabels = (options, labelFor) =>
  * @param {Object[]} extraFields - Additional fields to append (e.g., timepoint)
  * @returns {string} Vega expression for the tooltip signal
  */
-const buildNodeTooltipSignal = (nodeMetadata, branchMetadata, extraFields = []) => {
+// Sibling-ordering aggregates (#331) — shown in every node tooltip so the
+// values driving "Order children by" are visible without devtools.
+// "Max leaf distance" only means something when the tree has distance data
+// (matching the "max_leaf_distance" order-by option's own gating), so it's
+// only included when the caller confirms that via `hasDistance`.
+const buildOrderingTooltipFields = (hasDistance) => [
+  { field: "subtree_leaf_count", label: "Leaves in subtree" },
+  { field: "subtree_max_leaf_depth", label: "Max leaf depth in subtree" },
+  ...(hasDistance
+    ? [{ field: "subtree_max_leaf_distance", label: "Max leaf distance in subtree", format: ".3f" }]
+    : []),
+  { field: "subtree_total_multiplicity", label: "Total multiplicity in subtree" }
+];
+
+const buildNodeTooltipSignal = (nodeMetadata, branchMetadata, extraFields = [], hasDistance = false) => {
   const fields = [];
   const seen = new Set();
 
@@ -81,7 +95,9 @@ const buildNodeTooltipSignal = (nodeMetadata, branchMetadata, extraFields = []) 
     }
   }
 
-  return buildVegaTooltipExpr(fields.concat(extraFields), { nullFallback: "N/A" });
+  return buildVegaTooltipExpr(fields.concat(extraFields, buildOrderingTooltipFields(hasDistance)), {
+    nullFallback: "N/A"
+  });
 };
 
 /**
@@ -89,17 +105,22 @@ const buildNodeTooltipSignal = (nodeMetadata, branchMetadata, extraFields = []) 
  * Only adds timepoint fields when metadata is absent (fallback) or
  * when metadata explicitly declares timepoint fields.
  */
-const buildNodeTooltipWithTimepointSignal = (nodeMetadata, branchMetadata, hasFieldMetadata = false) => {
+const buildNodeTooltipWithTimepointSignal = (
+  nodeMetadata,
+  branchMetadata,
+  hasFieldMetadata = false,
+  hasDistance = false
+) => {
   // Only include timepoint fields when no metadata exists (old data likely has timepoints)
   // When metadata is present, timepoint fields should be declared there if available
   if (hasFieldMetadata) {
-    return buildNodeTooltipSignal(nodeMetadata, branchMetadata);
+    return buildNodeTooltipSignal(nodeMetadata, branchMetadata, [], hasDistance);
   }
   const timepointFields = [
     { field: "timepoint_multiplicity_key", label: "Timepoint" },
     { field: "timepoint_multiplicity_value", label: "Timepoint Multiplicity" }
   ];
-  return buildNodeTooltipSignal(nodeMetadata, branchMetadata, timepointFields);
+  return buildNodeTooltipSignal(nodeMetadata, branchMetadata, timepointFields, hasDistance);
 };
 
 // Vega filter: selects gap ("-") and unknown ("X") characters for special rendering
@@ -262,8 +283,14 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
   // Build dynamic node tooltip signals (includes branch metrics on child nodes)
   const branchMetadata = fieldMetadata?.branch || null;
   const hasFieldMeta = !!fieldMetadata;
-  const nodeTooltip = buildNodeTooltipSignal(nodeMetadata, branchMetadata);
-  const nodeTooltipWithTimepoint = buildNodeTooltipWithTimepointSignal(nodeMetadata, branchMetadata, hasFieldMeta);
+  const hasDistanceField = hasNodeField("distance");
+  const nodeTooltip = buildNodeTooltipSignal(nodeMetadata, branchMetadata, [], hasDistanceField);
+  const nodeTooltipWithTimepoint = buildNodeTooltipWithTimepointSignal(
+    nodeMetadata,
+    branchMetadata,
+    hasFieldMeta,
+    hasDistanceField
+  );
 
   // Build mutation coloring options from field_metadata.mutation
   // display: "dropdown" (default) → color option based on type
@@ -383,7 +410,7 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
           // tree transform's sort can stay a plain ascending sort.
           {
             type: "formula",
-            expr: "(child_order_desc ? -1 : 1) * (child_order_by == 'leaf_count' ? datum.subtree_leaf_count : child_order_by == 'max_leaf_depth' ? datum.subtree_max_leaf_depth : child_order_by == 'total_multiplicity' ? datum.subtree_total_multiplicity : datum.input_order_index)",
+            expr: "(child_order_desc ? -1 : 1) * (child_order_by == 'leaf_count' ? datum.subtree_leaf_count : child_order_by == 'max_leaf_depth' ? datum.subtree_max_leaf_depth : child_order_by == 'max_leaf_distance' ? datum.subtree_max_leaf_distance : child_order_by == 'total_multiplicity' ? datum.subtree_total_multiplicity : datum.input_order_index)",
             as: "child_sort_value"
           },
           {
@@ -928,14 +955,29 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
       },
       // Sibling ordering ("ladderize", #331). Default is "input" (today's
       // behavior — input-array order) so existing saved views/URLs are unaffected.
+      // "max_leaf_distance" (branch length from root, as opposed to
+      // "max_leaf_depth"'s topological edge count) is only offered when the
+      // tree actually has distance data, matching the "Branch length" control.
       {
         name: "child_order_by",
         value: "input",
         ...maybeAddBind({
           input: "select",
           name: "Order children by",
-          options: ["input", "leaf_count", "max_leaf_depth", "total_multiplicity"],
-          labels: ["Input order", "Number of leaves", "Max leaf depth", "Total leaf multiplicity"]
+          options: [
+            "input",
+            "leaf_count",
+            "max_leaf_depth",
+            ...(hasNodeField("distance") ? ["max_leaf_distance"] : []),
+            "total_multiplicity"
+          ],
+          labels: [
+            "Input order",
+            "Number of leaves",
+            "Max leaf depth",
+            ...(hasNodeField("distance") ? ["Max leaf distance from root"] : []),
+            "Total leaf multiplicity"
+          ]
         })
       },
       {

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -79,6 +79,10 @@ const buildOrderingTooltipFields = (hasDistance) => [
   { field: "subtree_total_multiplicity", label: "Total multiplicity in subtree" }
 ];
 
+// Builds a node tooltip expression that switches, at hover time, on the
+// `show_ordering_tooltip_fields` signal — a plain Vega ternary over two
+// pre-built object-literal expressions, so toggling the checkbox needs no
+// spec rebuild (see the "Show ordering info in tooltip" control).
 const buildNodeTooltipSignal = (nodeMetadata, branchMetadata, extraFields = [], hasDistance = false) => {
   const fields = [];
   const seen = new Set();
@@ -95,9 +99,11 @@ const buildNodeTooltipSignal = (nodeMetadata, branchMetadata, extraFields = [], 
     }
   }
 
-  return buildVegaTooltipExpr(fields.concat(extraFields, buildOrderingTooltipFields(hasDistance)), {
+  const withoutOrdering = buildVegaTooltipExpr(fields.concat(extraFields), { nullFallback: "N/A" });
+  const withOrdering = buildVegaTooltipExpr(fields.concat(extraFields, buildOrderingTooltipFields(hasDistance)), {
     nullFallback: "N/A"
   });
+  return `(show_ordering_tooltip_fields ? (${withOrdering}) : (${withoutOrdering}))`;
 };
 
 /**
@@ -986,6 +992,14 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         ...maybeAddBind({
           input: "checkbox",
           name: "Order children descending"
+        })
+      },
+      {
+        name: "show_ordering_tooltip_fields",
+        value: false,
+        ...maybeAddBind({
+          input: "checkbox",
+          name: "Show ordering info in tooltip"
         })
       },
       // === DISPLAY CONTROLS ===

--- a/src/components/explorer/vega/clonalFamilyDetails.js
+++ b/src/components/explorer/vega/clonalFamilyDetails.js
@@ -377,6 +377,15 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         name: "tree",
         transform: [
           { key: "sequence_id", type: "stratify", parentKey: "parent" },
+          // Sibling ordering (#331): pick the precomputed subtree aggregate the
+          // "Order children by" control points at (defaulting to the original
+          // input-array order), negating it when descending is checked so the
+          // tree transform's sort can stay a plain ascending sort.
+          {
+            type: "formula",
+            expr: "(child_order_desc ? -1 : 1) * (child_order_by == 'leaf_count' ? datum.subtree_leaf_count : child_order_by == 'max_leaf_depth' ? datum.subtree_max_leaf_depth : child_order_by == 'total_multiplicity' ? datum.subtree_total_multiplicity : datum.input_order_index)",
+            as: "child_sort_value"
+          },
           {
             // The size of the tree here should be constant with the number of leaves;
             // the zoom signals rely on xext, yext to be the same no matter the zoom
@@ -386,7 +395,11 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
             separation: false,
             // We are only using the y values from this transform, x comes from "distance"
             size: [{ signal: "leaves_count_incl_naive" }, { signal: "width" }],
-            as: ["y_tree", "x_tree", "depth", "children"]
+            as: ["y_tree", "x_tree", "depth", "children"],
+            // d3-hierarchy's node.sort() calls this comparator with the tree
+            // node wrapper, not the raw datum — the field lives one level
+            // down at node.data.<field>.
+            sort: { field: "data.child_sort_value", order: "ascending" }
           },
 
           // Calculate x_raw based on the current mode (for extent calculation)
@@ -912,6 +925,26 @@ const concatTreeWithAlignmentSpec = (options = {}) => {
         name: "branch_color_scale",
         update:
           'indexof(categorical_seq_metrics, branch_color_by) > 0 ? "branch_color_categorical" : "branch_color_sequential"'
+      },
+      // Sibling ordering ("ladderize", #331). Default is "input" (today's
+      // behavior — input-array order) so existing saved views/URLs are unaffected.
+      {
+        name: "child_order_by",
+        value: "input",
+        ...maybeAddBind({
+          input: "select",
+          name: "Order children by",
+          options: ["input", "leaf_count", "max_leaf_depth", "total_multiplicity"],
+          labels: ["Input order", "Number of leaves", "Max leaf depth", "Total leaf multiplicity"]
+        })
+      },
+      {
+        name: "child_order_desc",
+        value: false,
+        ...maybeAddBind({
+          input: "checkbox",
+          name: "Order children descending"
+        })
       },
       // === DISPLAY CONTROLS ===
       {

--- a/src/selectors/__tests__/trees.test.js
+++ b/src/selectors/__tests__/trees.test.js
@@ -139,6 +139,69 @@ describe("computeTreeData", () => {
     expect(mutAtPos3.selection_contribution).toBe(4.1);
     expect(mutAtPos3.region).toBe("CDR2");
   });
+
+  describe("subtree ordering aggregates (#331)", () => {
+    it("computes leaf count / max leaf depth / total multiplicity for a simple tree", () => {
+      const result = computeTreeData(mockTree);
+      const byId = Object.fromEntries(result.nodes.map((n) => [n.sequence_id, n]));
+
+      // inferred_naive -> internal-1 -> {leaf-1 (mult 2), leaf-2 (mult 1)}, both leaves at depth 2
+      expect(byId["leaf-1"].subtree_leaf_count).toBe(1);
+      expect(byId["leaf-1"].subtree_max_leaf_depth).toBe(2);
+      expect(byId["leaf-1"].subtree_total_multiplicity).toBe(2);
+
+      expect(byId["internal-1"].subtree_leaf_count).toBe(2);
+      expect(byId["internal-1"].subtree_max_leaf_depth).toBe(2);
+      expect(byId["internal-1"].subtree_total_multiplicity).toBe(3);
+
+      expect(byId["inferred_naive"].subtree_leaf_count).toBe(2);
+      expect(byId["inferred_naive"].subtree_max_leaf_depth).toBe(2);
+      expect(byId["inferred_naive"].subtree_total_multiplicity).toBe(3);
+
+      // input_order_index mirrors the (post-normalization) array position
+      expect(byId["inferred_naive"].input_order_index).toBe(0);
+      expect(byId["internal-1"].input_order_index).toBe(1);
+      expect(byId["leaf-1"].input_order_index).toBe(2);
+      expect(byId["leaf-2"].input_order_index).toBe(3);
+    });
+
+    it("distinguishes leaf count, max leaf depth, and multiplicity across asymmetric siblings", () => {
+      // root -> A (leaf, mult 10, depth 1)
+      //      -> B -> B1 -> B1a (leaf, mult 1, depth 3)
+      //           -> B2 (leaf, mult 1, depth 2)
+      const asymmetricTree = {
+        ident: "tree-asym",
+        nodes: [
+          { sequence_id: "root", type: "root", parent: null, sequence_alignment_aa: "MKVL" },
+          { sequence_id: "A", type: "leaf", parent: "root", sequence_alignment_aa: "MKVL", multiplicity: 10 },
+          { sequence_id: "B", type: "internal", parent: "root", sequence_alignment_aa: "MKVL" },
+          { sequence_id: "B1", type: "internal", parent: "B", sequence_alignment_aa: "MKVL" },
+          { sequence_id: "B1a", type: "leaf", parent: "B1", sequence_alignment_aa: "MKVL", multiplicity: 1 },
+          { sequence_id: "B2", type: "leaf", parent: "B", sequence_alignment_aa: "MKVL", multiplicity: 1 }
+        ]
+      };
+      const result = computeTreeData(asymmetricTree);
+      const byId = Object.fromEntries(result.nodes.map((n) => [n.sequence_id, n]));
+
+      // A: single leaf, shallow, but high multiplicity
+      expect(byId["A"]).toMatchObject({
+        subtree_leaf_count: 1,
+        subtree_max_leaf_depth: 1,
+        subtree_total_multiplicity: 10
+      });
+      // B: two leaves, deeper, but lower total multiplicity than A
+      expect(byId["B"]).toMatchObject({
+        subtree_leaf_count: 2,
+        subtree_max_leaf_depth: 3,
+        subtree_total_multiplicity: 2
+      });
+      // By leaf count or multiplicity B and A would order one way; by max leaf
+      // depth the other way — confirms the three metrics are independent.
+      expect(byId["B"].subtree_leaf_count).toBeGreaterThan(byId["A"].subtree_leaf_count);
+      expect(byId["B"].subtree_max_leaf_depth).toBeGreaterThan(byId["A"].subtree_max_leaf_depth);
+      expect(byId["B"].subtree_total_multiplicity).toBeLessThan(byId["A"].subtree_total_multiplicity);
+    });
+  });
 });
 
 describe("computeLineageDataWithOptions", () => {

--- a/src/selectors/__tests__/trees.test.js
+++ b/src/selectors/__tests__/trees.test.js
@@ -146,16 +146,20 @@ describe("computeTreeData", () => {
       const byId = Object.fromEntries(result.nodes.map((n) => [n.sequence_id, n]));
 
       // inferred_naive -> internal-1 -> {leaf-1 (mult 2), leaf-2 (mult 1)}, both leaves at depth 2
+      // mockTreeNodes has no `distance` field, so it falls back to 0.
       expect(byId["leaf-1"].subtree_leaf_count).toBe(1);
       expect(byId["leaf-1"].subtree_max_leaf_depth).toBe(2);
+      expect(byId["leaf-1"].subtree_max_leaf_distance).toBe(0);
       expect(byId["leaf-1"].subtree_total_multiplicity).toBe(2);
 
       expect(byId["internal-1"].subtree_leaf_count).toBe(2);
       expect(byId["internal-1"].subtree_max_leaf_depth).toBe(2);
+      expect(byId["internal-1"].subtree_max_leaf_distance).toBe(0);
       expect(byId["internal-1"].subtree_total_multiplicity).toBe(3);
 
       expect(byId["inferred_naive"].subtree_leaf_count).toBe(2);
       expect(byId["inferred_naive"].subtree_max_leaf_depth).toBe(2);
+      expect(byId["inferred_naive"].subtree_max_leaf_distance).toBe(0);
       expect(byId["inferred_naive"].subtree_total_multiplicity).toBe(3);
 
       // input_order_index mirrors the (post-normalization) array position
@@ -165,40 +169,66 @@ describe("computeTreeData", () => {
       expect(byId["leaf-2"].input_order_index).toBe(3);
     });
 
-    it("distinguishes leaf count, max leaf depth, and multiplicity across asymmetric siblings", () => {
-      // root -> A (leaf, mult 10, depth 1)
-      //      -> B -> B1 -> B1a (leaf, mult 1, depth 3)
-      //           -> B2 (leaf, mult 1, depth 2)
+    it("distinguishes leaf count, max leaf depth, max leaf distance, and multiplicity across asymmetric siblings", () => {
+      // root -> A (leaf, mult 10, depth 1, one long branch: distance 0.5)
+      //      -> B -> B1 -> B1a (leaf, mult 1, depth 3, short branches: distance 0.1)
+      //           -> B2 (leaf, mult 1, depth 2, distance 0.05)
       const asymmetricTree = {
         ident: "tree-asym",
         nodes: [
           { sequence_id: "root", type: "root", parent: null, sequence_alignment_aa: "MKVL" },
-          { sequence_id: "A", type: "leaf", parent: "root", sequence_alignment_aa: "MKVL", multiplicity: 10 },
+          {
+            sequence_id: "A",
+            type: "leaf",
+            parent: "root",
+            sequence_alignment_aa: "MKVL",
+            multiplicity: 10,
+            distance: 0.5
+          },
           { sequence_id: "B", type: "internal", parent: "root", sequence_alignment_aa: "MKVL" },
           { sequence_id: "B1", type: "internal", parent: "B", sequence_alignment_aa: "MKVL" },
-          { sequence_id: "B1a", type: "leaf", parent: "B1", sequence_alignment_aa: "MKVL", multiplicity: 1 },
-          { sequence_id: "B2", type: "leaf", parent: "B", sequence_alignment_aa: "MKVL", multiplicity: 1 }
+          {
+            sequence_id: "B1a",
+            type: "leaf",
+            parent: "B1",
+            sequence_alignment_aa: "MKVL",
+            multiplicity: 1,
+            distance: 0.1
+          },
+          {
+            sequence_id: "B2",
+            type: "leaf",
+            parent: "B",
+            sequence_alignment_aa: "MKVL",
+            multiplicity: 1,
+            distance: 0.05
+          }
         ]
       };
       const result = computeTreeData(asymmetricTree);
       const byId = Object.fromEntries(result.nodes.map((n) => [n.sequence_id, n]));
 
-      // A: single leaf, shallow, but high multiplicity
+      // A: single leaf, shallow but on a long branch, high multiplicity
       expect(byId["A"]).toMatchObject({
         subtree_leaf_count: 1,
         subtree_max_leaf_depth: 1,
+        subtree_max_leaf_distance: 0.5,
         subtree_total_multiplicity: 10
       });
-      // B: two leaves, deeper, but lower total multiplicity than A
+      // B: two leaves, topologically deeper but on short branches, lower total multiplicity than A
       expect(byId["B"]).toMatchObject({
         subtree_leaf_count: 2,
         subtree_max_leaf_depth: 3,
+        subtree_max_leaf_distance: 0.1,
         subtree_total_multiplicity: 2
       });
-      // By leaf count or multiplicity B and A would order one way; by max leaf
-      // depth the other way — confirms the three metrics are independent.
+      // By leaf count or topological depth B ranks above A; by branch-length
+      // distance or multiplicity A ranks above B — confirms the four metrics
+      // are independent (topological depth and branch-length distance in
+      // particular can and do disagree).
       expect(byId["B"].subtree_leaf_count).toBeGreaterThan(byId["A"].subtree_leaf_count);
       expect(byId["B"].subtree_max_leaf_depth).toBeGreaterThan(byId["A"].subtree_max_leaf_depth);
+      expect(byId["B"].subtree_max_leaf_distance).toBeLessThan(byId["A"].subtree_max_leaf_distance);
       expect(byId["B"].subtree_total_multiplicity).toBeLessThan(byId["A"].subtree_total_multiplicity);
     });
   });

--- a/src/selectors/trees.js
+++ b/src/selectors/trees.js
@@ -248,6 +248,47 @@ const buildConsensus = (sequences) => {
   return consensus;
 };
 
+/**
+ * Bottom-up per-node subtree aggregates used to order tree children (#331):
+ * leaf count, deepest-leaf depth, and total leaf multiplicity across each
+ * node's own subtree. `bfsOrder` (root-first, non-decreasing depth, from the
+ * caller's BFS) lets this fold each node into its parent in a single reverse
+ * pass — every descendant is folded in before its ancestor's turn comes,
+ * since descendants always sort later in `bfsOrder`.
+ */
+const computeSubtreeOrderingAggregates = (nodes, childrenMap, depthMap, bfsOrder) => {
+  const leafCount = {};
+  const maxLeafDepth = {};
+  const totalMultiplicity = {};
+  const parentById = {};
+
+  for (const node of nodes) {
+    const id = node.sequence_id;
+    parentById[id] = node.parent || null;
+    const isLeaf = !childrenMap[id] || childrenMap[id].length === 0;
+    if (isLeaf) {
+      leafCount[id] = 1;
+      maxLeafDepth[id] = depthMap[id] ?? 0;
+      totalMultiplicity[id] = node.multiplicity || 0;
+    } else {
+      leafCount[id] = 0;
+      maxLeafDepth[id] = 0;
+      totalMultiplicity[id] = 0;
+    }
+  }
+
+  for (let i = bfsOrder.length - 1; i >= 0; i--) {
+    const id = bfsOrder[i];
+    const parentId = parentById[id];
+    if (!parentId) continue;
+    leafCount[parentId] += leafCount[id];
+    maxLeafDepth[parentId] = Math.max(maxLeafDepth[parentId], maxLeafDepth[id]);
+    totalMultiplicity[parentId] += totalMultiplicity[id];
+  }
+
+  return { leafCount, maxLeafDepth, totalMultiplicity };
+};
+
 const SYNTHETIC_ROOT_ID = "__synthetic_root__";
 
 /**
@@ -364,16 +405,34 @@ export const computeTreeData = (tree) => {
     }
     if (rootId) {
       const depthMap = {};
+      const bfsOrder = [];
       const queue = [[rootId, 0]];
       while (queue.length > 0) {
         const [nodeId, d] = queue.shift();
         depthMap[nodeId] = d;
+        bfsOrder.push(nodeId);
         for (const childId of childrenMap[nodeId] || []) {
           queue.push([childId, d + 1]);
         }
       }
-      treeData.nodes = treeData.nodes.map((n) =>
-        depthMap[n.sequence_id] !== undefined ? { ...n, node_depth: depthMap[n.sequence_id] } : n
+      const { leafCount, maxLeafDepth, totalMultiplicity } = computeSubtreeOrderingAggregates(
+        treeData.nodes,
+        childrenMap,
+        depthMap,
+        bfsOrder
+      );
+      treeData.nodes = treeData.nodes.map((n, index) =>
+        depthMap[n.sequence_id] !== undefined
+          ? {
+              ...n,
+              node_depth: depthMap[n.sequence_id],
+              // Ordering aggregates for the tree view's "order children by" control (#331)
+              subtree_leaf_count: leafCount[n.sequence_id],
+              subtree_max_leaf_depth: maxLeafDepth[n.sequence_id],
+              subtree_total_multiplicity: totalMultiplicity[n.sequence_id],
+              input_order_index: index
+            }
+          : n
       );
     }
   }

--- a/src/selectors/trees.js
+++ b/src/selectors/trees.js
@@ -250,8 +250,9 @@ const buildConsensus = (sequences) => {
 
 /**
  * Bottom-up per-node subtree aggregates used to order tree children (#331):
- * leaf count, deepest-leaf depth, and total leaf multiplicity across each
- * node's own subtree. `bfsOrder` (root-first, non-decreasing depth, from the
+ * leaf count, deepest-leaf depth (topological), deepest-leaf distance
+ * (branch length from root), and total leaf multiplicity across each node's
+ * own subtree. `bfsOrder` (root-first, non-decreasing depth, from the
  * caller's BFS) lets this fold each node into its parent in a single reverse
  * pass — every descendant is folded in before its ancestor's turn comes,
  * since descendants always sort later in `bfsOrder`.
@@ -259,6 +260,7 @@ const buildConsensus = (sequences) => {
 const computeSubtreeOrderingAggregates = (nodes, childrenMap, depthMap, bfsOrder) => {
   const leafCount = {};
   const maxLeafDepth = {};
+  const maxLeafDistance = {};
   const totalMultiplicity = {};
   const parentById = {};
 
@@ -269,10 +271,12 @@ const computeSubtreeOrderingAggregates = (nodes, childrenMap, depthMap, bfsOrder
     if (isLeaf) {
       leafCount[id] = 1;
       maxLeafDepth[id] = depthMap[id] ?? 0;
+      maxLeafDistance[id] = node.distance || 0;
       totalMultiplicity[id] = node.multiplicity || 0;
     } else {
       leafCount[id] = 0;
       maxLeafDepth[id] = 0;
+      maxLeafDistance[id] = 0;
       totalMultiplicity[id] = 0;
     }
   }
@@ -283,10 +287,11 @@ const computeSubtreeOrderingAggregates = (nodes, childrenMap, depthMap, bfsOrder
     if (!parentId) continue;
     leafCount[parentId] += leafCount[id];
     maxLeafDepth[parentId] = Math.max(maxLeafDepth[parentId], maxLeafDepth[id]);
+    maxLeafDistance[parentId] = Math.max(maxLeafDistance[parentId], maxLeafDistance[id]);
     totalMultiplicity[parentId] += totalMultiplicity[id];
   }
 
-  return { leafCount, maxLeafDepth, totalMultiplicity };
+  return { leafCount, maxLeafDepth, maxLeafDistance, totalMultiplicity };
 };
 
 const SYNTHETIC_ROOT_ID = "__synthetic_root__";
@@ -415,7 +420,7 @@ export const computeTreeData = (tree) => {
           queue.push([childId, d + 1]);
         }
       }
-      const { leafCount, maxLeafDepth, totalMultiplicity } = computeSubtreeOrderingAggregates(
+      const { leafCount, maxLeafDepth, maxLeafDistance, totalMultiplicity } = computeSubtreeOrderingAggregates(
         treeData.nodes,
         childrenMap,
         depthMap,
@@ -429,6 +434,7 @@ export const computeTreeData = (tree) => {
               // Ordering aggregates for the tree view's "order children by" control (#331)
               subtree_leaf_count: leafCount[n.sequence_id],
               subtree_max_leaf_depth: maxLeafDepth[n.sequence_id],
+              subtree_max_leaf_distance: maxLeafDistance[n.sequence_id],
               subtree_total_multiplicity: totalMultiplicity[n.sequence_id],
               input_order_index: index
             }

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -49,6 +49,7 @@ export const TREE_SIGNALS = [
   // Sibling ordering ("ladderize", #331)
   "child_order_by",
   "child_order_desc",
+  "show_ordering_tooltip_fields",
   // Alignment zoom/pan state (tree zoom/pan are computed signals, not directly settable)
   "alignment_zoom",
   "alignment_pan"
@@ -91,6 +92,7 @@ export const DEFAULT_TREE_SETTINGS = {
   // Sibling ordering ("ladderize", #331) defaults
   child_order_by: "input",
   child_order_desc: false,
+  show_ordering_tooltip_fields: false,
   // Alignment zoom/pan defaults
   alignment_zoom: 1,
   alignment_pan: 0

--- a/src/utils/configManager.js
+++ b/src/utils/configManager.js
@@ -46,6 +46,9 @@ export const TREE_SIGNALS = [
   "show_alignment",
   "show_mutation_borders",
   "show_controls",
+  // Sibling ordering ("ladderize", #331)
+  "child_order_by",
+  "child_order_desc",
   // Alignment zoom/pan state (tree zoom/pan are computed signals, not directly settable)
   "alignment_zoom",
   "alignment_pan"
@@ -85,6 +88,9 @@ export const DEFAULT_TREE_SETTINGS = {
   show_alignment: true,
   show_mutation_borders: false,
   show_controls: true,
+  // Sibling ordering ("ladderize", #331) defaults
+  child_order_by: "input",
+  child_order_desc: false,
   // Alignment zoom/pan defaults
   alignment_zoom: 1,
   alignment_pan: 0


### PR DESCRIPTION
closes #331: a "ladderize"-style control on the tree (Phylogeny) view for ordering the children of each parent node.

## Summary

- **"Order children by" dropdown** on the tree control panel: input order (default — today's behavior, so existing saved views/URLs are unaffected), number of leaves, max leaf depth (topological, edge count from root), max leaf distance from root (branch length — only offered when the tree has distance data, matching the existing "Branch length" control's gating), or total leaf multiplicity — applied recursively via the Vega `tree` transform's `sort`. Plus an "Order children descending" checkbox.
- **Aggregates computed once, client-side, in the selector** — not per-dropdown-change, and not pushed to olmsted-cli. `computeTreeData` (`src/selectors/trees.js`) already does a top-down BFS to compute `node_depth`; this adds a bottom-up fold in the same pass (reusing the BFS visitation order in reverse) to compute `subtree_leaf_count`, `subtree_max_leaf_depth`, `subtree_max_leaf_distance`, and `subtree_total_multiplicity` per node, plus `input_order_index` for the default ordering. This is memoized on the tree itself (`getTreeData = createSelector([getSelectedTree], ...)`), so it runs once per tree load and is untouched by the ordering control.
- **Implemented as Vega-bound signals** (`child_order_by`, `child_order_desc`), matching every other tree control (`branch_color_by`, `branch_width_by`, `show_labels`, etc.) rather than introducing a separate Redux-backed persistence path for just this one control. Registered in `configManager.js`'s `TREE_SIGNALS`/`DEFAULT_TREE_SETTINGS` so the choice round-trips through named configs like its siblings.
- **Node tooltips can show all four subtree aggregates** (leaves in subtree, max leaf depth, max leaf distance, total multiplicity) — added so the values driving the ordering control are visible without devtools. The distance one is gated the same way as the dropdown option (only shown when the tree has distance data). Behind a **"Show ordering info in tooltip" checkbox** (default off) so it doesn't clutter the tooltip by default — implemented as a runtime ternary on the tooltip's Vega expression (two pre-built variants gated on a `show_ordering_tooltip_fields` signal), not a spec rebuild, so toggling it is instant.

## Why not push the aggregates to olmsted-cli?

Considered and rejected — see discussion in the PR/issue. Short version: the computation is a cheap, purely structural/presentational property (same category as the already-selector-computed `node_depth`, not a scientific metric like LBI/LBR which *is* computed in olmsted-cli). Moving it to CLI would mean a cross-repo Olmsted-JSON format change (DESIGN.md D9) for every future ordering metric, plus shipping unused precomputed fields with every tree regardless of whether ladderize is ever used, for no performance benefit (the traversal is O(n) over typically small trees and already memoized).

## Testing

- New selector tests (`src/selectors/__tests__/trees.test.js`) for the aggregate math on both a simple and an asymmetric tree — the asymmetric case has leaves with disagreeing depth, distance, and multiplicity, confirming all four metrics are read independently (in particular, topological depth and branch-length distance don't have to agree).
- New **headless Vega `View` runtime tests** (`clonalFamilyDetails.test.js`) that actually run the sort and assert the resulting `y_tree` order — not just that the spec parses. This caught a real bug during development: d3-hierarchy's `node.sort()` invokes the comparator with the tree-node wrapper (`node.data.<field>`), not the raw datum, so the sort field had to be `"data.child_sort_value"` rather than `"child_sort_value"`. A parse-only test would have passed either way. Mock tree data was set up so max-leaf-distance and total-multiplicity orderings disagree, so the runtime test also confirms the two fields aren't being conflated.
- New spec-level tests confirming the `show_ordering_tooltip_fields` checkbox signal exists (default off) and that the tooltip expression is actually gated on it.
- `npm test` — 663 passing
- `npm run lint` / `npm run format:check` — clean
- `npm run build` — succeeds

Not done: manual browser click-through of the new dropdown on a real multi-clade tree — worth a pass before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

