### PR TITLE
Document AIRR format consistency with olmsted-cli#47

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ See **[PRE-MERGE-CHECKLIST.md](./PRE-MERGE-CHECKLIST.md)** for the full checklis
 
 ### Data Formats
 
-- **AIRR**: Adaptive Immune Receptor Repertoire - JSON format following AIRR Community standards
+- **AIRR**: Adaptive Immune Receptor Repertoire. olmsted-cli currently accepts two JSON input variants named `-f airr` and `-f airr2`, but only `airr2` (the AIRR-C v2 Clone/Tree/Node/Cell schema, the format Dowser's `writeTreesJSON` emits) corresponds to an actual official AIRR Community schema release. `-f airr` (legacy) reuses some AIRR field names inside an Olmsted-specific container that was never part of any official AIRR release. [matsengrp/olmsted-cli#47](https://github.com/matsengrp/olmsted-cli/issues/47) tracks removing the legacy format and renaming `airr2` to `airr`, since only one variant will remain — check that issue for current status before assuming which shape `-f airr` means.
 - **PCP**: Parent-Child Pair - CSV format with phylogenetic relationships and optional Newick trees
 - **Olmsted JSON**: Internal format produced by olmsted-cli, consumed by the web application
 

--- a/README.md
+++ b/README.md
@@ -126,9 +126,11 @@ Example PCP data can be found in the `olmsted-cli/example_data/` directory, demo
 
 #### AIRR Format
 
+**Note**: olmsted-cli currently accepts two AIRR-flavored JSON inputs, `-f airr` (legacy) and `-f airr2`. Only `airr2` corresponds to an official AIRR Community schema release — the **AIRR-C v2 Clone/Tree/Node/Cell schema** (AIRR Schema v2.0.0), documented at [docs.airr-community.org/en/latest/datarep/clone.html](https://docs.airr-community.org/en/latest/datarep/clone.html). The legacy `-f airr` container was never part of any official AIRR release, despite reusing some AIRR field names; [matsengrp/olmsted-cli#47](https://github.com/matsengrp/olmsted-cli/issues/47) tracks removing it and renaming `airr2` to `airr`. See [olmsted-cli's FORMATS.md](https://github.com/matsengrp/olmsted-cli/blob/main/FORMATS.md) for the authoritative, current field-level mapping — the summary below may be stale once that issue lands.
+
 The AIRR JSON format is described [here](https://github.com/airr-community/airr-standards/blob/master/specs/airr-schema.yaml).
 A list of tools that output this format can be found [here](https://docs.airr-community.org/en/stable/resources/rearrangement_support.html).
-For a human-readable version of the schema, see [olmstedviz.org/schema.html](http://www.olmstedviz.org/schema.html) or view [schema.html](https://github.com/matsengrp/olmsted/blob/main/schema.html) on [htmlpreview.github.io](https://htmlpreview.github.io).
+For a human-readable version of the Olmsted output schema, see [olmstedviz.org/schema.html](http://www.olmstedviz.org/schema.html) or view [schema.html](https://github.com/matsengrp/olmsted/blob/main/schema.html) on [htmlpreview.github.io](https://htmlpreview.github.io).
 
 ### Validation
 

--- a/tutorial/format-airr.md
+++ b/tutorial/format-airr.md
@@ -1,5 +1,20 @@
 # AIRR (Adaptive Immune Receptor Repertoire) Format
 
+> **Note**: This page documents olmsted-cli's **legacy** `-f airr` input (the
+> nested `{ident, subjects, samples, seeds, clones}` shape below). Research
+> into its provenance found that, despite reusing some AIRR field names, this
+> container was never part of any official AIRR Community schema release, at
+> any version — see the field-by-field breakdown in
+> [matsengrp/olmsted-cli#47](https://github.com/matsengrp/olmsted-cli/issues/47).
+> That issue tracks removing this legacy format and renaming olmsted-cli's
+> other AIRR input, `-f airr2` (which *does* implement an official schema —
+> the AIRR-C v2 Clone/Tree/Node/Cell schema, AIRR Schema v2.0.0), to `-f airr`
+> in its place. Once that lands, this page will need a rewrite to describe
+> the new shape; until then, treat the content below as describing what
+> will become a removed format, and see
+> [olmsted-cli's FORMATS.md](https://github.com/matsengrp/olmsted-cli/blob/main/FORMATS.md)
+> for the current, authoritative format descriptions.
+
 ## Overview
 
 AIRR format is a JSON-based standard developed by the AIRR Community for representing adaptive immune receptor repertoire sequencing data, including B and T cell receptor sequences, clonal families, and phylogenetic relationships.

--- a/tutorial/tutorial-outline.md
+++ b/tutorial/tutorial-outline.md
@@ -346,6 +346,7 @@
   - **Reference**: See `tutorial/format-pcp.md` for full specification
 
 - **AIRR (Adaptive Immune Receptor Repertoire) Format**:
+  - **Note**: [matsengrp/olmsted-cli#47](https://github.com/matsengrp/olmsted-cli/issues/47) tracks removing today's legacy `-f airr` (the nested samples → clones → trees → nodes shape below, which does not correspond to any official AIRR release) and renaming `-f airr2` (the real AIRR-C v2 Clone/Tree/Node/Cell schema) to `-f airr`. Confirm that issue's status before recording a tutorial video against this section.
   - **Single JSON file** following AIRR Community standards
   - Show example from `olmsted-cli/example_data/airr/`
   - Nested structure: samples → clones → trees → nodes


### PR DESCRIPTION
## Summary
- Research into the provenance of olmsted-cli's two AIRR input formats found that legacy `-f airr` was never part of any official AIRR Community schema release, at any version — only `-f airr2` (the AIRR-C v2 Clone/Tree/Node/Cell schema, AIRR Schema v2.0.0) is. Full field-by-field breakdown is in [matsengrp/olmsted-cli#47](https://github.com/matsengrp/olmsted-cli/issues/47), which tracks removing the legacy format and renaming `airr2` → `airr`.
- Updates the webapp-side docs that described the legacy shape as "the" AIRR standard, so they're consistent with that decision instead of stale/misleading in the meantime:
  - `CLAUDE.md` — AIRR terminology bullet now explains the two variants and links to olmsted-cli#47
  - `README.md` — AIRR Format section leads with the same note, points to olmsted-cli's `FORMATS.md` as authoritative, and fixes a separate pre-existing mislabel (`schema.html` is the Olmsted *output* schema, not an AIRR input schema)
  - `tutorial/format-airr.md` — notice that this page documents the format slated for removal
  - `tutorial/tutorial-outline.md` — same caveat, so a tutorial video isn't recorded against the soon-to-be-removed shape
- No code changes — the webapp doesn't branch on the `"airr"` format-name string anywhere.

## Test plan
- [x] Docs-only change; no code paths affected
- [x] Reviewer sanity-check that the linked olmsted-cli#47 summary matches