### PR TITLE
Add deprecation notice for split-format uploads (#292 phase 1)

### DIFF
--- a/src/components/splash/fileUpload.js
+++ b/src/components/splash/fileUpload.js
@@ -143,7 +143,7 @@ class FileUpload extends React.Component {
 
       if (!fileType) {
         throw new Error(
-          "Unsupported file type. Please upload olmsted-cli consolidated JSON files (.json or .json.gz). For split files, select all files together (datasets.json, clones.*.json, tree.*.json)."
+          "Unsupported file type. Please upload olmsted-cli consolidated JSON files (.json or .json.gz). For split files, select all files together (datasets.json, clones.*.json, tree.*.json) — note this format is deprecated and will be removed in a future release; regenerate your data with a current olmsted-cli, which produces a single consolidated JSON file."
         );
       }
 
@@ -558,14 +558,18 @@ class FileUpload extends React.Component {
               {uploadedFiles.some(
                 (f) =>
                   !this.state.dismissedWarnings.has(f.datasetId) &&
-                  (f.missingFieldWarnings?.length > 0 || f.dataModifications?.length > 0)
+                  (f.missingFieldWarnings?.length > 0 ||
+                    f.dataModifications?.length > 0 ||
+                    f.fileType === "consolidated-split")
               ) && (
                 <div style={{ marginBottom: 10 }}>
                   {uploadedFiles
                     .filter(
                       (f) =>
                         !this.state.dismissedWarnings.has(f.datasetId) &&
-                        (f.missingFieldWarnings?.length > 0 || f.dataModifications?.length > 0)
+                        (f.missingFieldWarnings?.length > 0 ||
+                          f.dataModifications?.length > 0 ||
+                          f.fileType === "consolidated-split")
                     )
                     .map((file) => (
                       <div
@@ -614,6 +618,13 @@ class FileUpload extends React.Component {
                             &times;
                           </button>
                         </div>
+                        {file.fileType === "consolidated-split" && (
+                          <div style={{ marginBottom: 4 }}>
+                            This dataset was uploaded using the <strong>split-file (multi-file) format</strong>, which
+                            is deprecated and will be removed in a future release. Regenerate it with a current
+                            olmsted-cli, which produces a single consolidated JSON file, to avoid disruption.
+                          </div>
+                        )}
                         {file.missingFieldWarnings?.length > 0 && (
                           <div style={{ marginBottom: 4 }}>
                             <strong>Missing data fields:</strong>


### PR DESCRIPTION
## Summary

Phase 1 of #292 ("Sunset split-style dataset upload support"). Ships a deprecation notice rather than removing outright, per the issue's own open question: is anyone still uploading split-format files? Unknown either way, so this lands a warning first.

- A dismissible warning banner (reusing the existing missing-field/data-modification warning UI pattern) now appears after a successful split-format upload, telling the user this path is deprecated and will be removed in a future release.
- The unsupported-file-type error message (which already mentions split files as an option for users hitting an upload error) now also notes the deprecation.
- **No functional removal in this PR** — `splitFileProcessor.js`, the split-detection branch in `onDrop`, and the multi-file `<input>` accept list are all unchanged and continue to work exactly as before.

## A scope correction for the eventual removal PR

While investigating, found that the `acceptedFiles.length > 1` branch in `onDrop` does two things, not one: split-format detection, *and* falling through to bulk-uploading multiple independent consolidated files in parallel when split-detection fails (the Dropzone explicitly sets `multiple`, and this is a real, separate capability, not a split-format side effect). #292's checklist says "simplify the Dropzone to single-file," which would drop that bulk-upload capability too as a side effect — flagged this on the issue so the follow-up removal PR only removes split-detection, not bulk multi-file upload.

## Test plan

- [x] `eslint` clean (no new warnings/errors beyond 3 pre-existing, unrelated ones)
- [x] `prettier --check` clean
- [x] Existing `splitFileProcessor.test.js` suite: 29/29 passing, unchanged
- [x] **Real browser verification** (Playwright, headless Chromium, ad hoc script not committed): uploaded a real split-format fileset (retrieved from olmsted-cli git history, since the producer side was removed in olmsted-cli#43) — banner appears, is dismissible, and the dataset still loads successfully afterward. Also verified single-file upload is unaffected.

## Follow-up (not in this PR)

Phase 2, tracked on #292: once this has shipped for a release, delete `splitFileProcessor.js` + its test, remove the split-detection branch, and update the supported-formats hint — leaving the bulk-multi-file-upload behavior intact.